### PR TITLE
Override to_solr in AdminPolicy to index display title consistent with DulHydra::Models::Base.

### DIFF
--- a/app/models/admin_policy.rb
+++ b/app/models/admin_policy.rb
@@ -20,6 +20,12 @@ class AdminPolicy < Hydra::AdminPolicy
     [:title, :description]
   end
 
+  def to_solr(solr_doc=Hash.new, opts={})
+    solr_doc = super(solr_doc, opts)
+    solr_doc.merge!(DulHydra::IndexFields::TITLE => title || pid)
+    solr_doc
+  end
+
   #
   # Load admin policy objects from YAML file
   #

--- a/spec/models/admin_policy_spec.rb
+++ b/spec/models/admin_policy_spec.rb
@@ -14,6 +14,18 @@ describe AdminPolicy do
       apo.defaultRights.license.url.first.should == "http://library.duke.edu"
     end
   end
+  context "indexing" do
+    subject { SolrDocument.new(ActiveFedora::SolrService.query(ActiveFedora::SolrService.construct_query_for_pids([apo.pid])).first) }
+    after { apo.delete }
+    context "no title" do
+      let(:apo) { AdminPolicy.create }
+      its(:title) { should == apo.pid }
+    end
+    context "has title" do
+      let(:apo) { AdminPolicy.create(title: 'Awesome Policy') }
+      its(:title) { should == apo.title }
+    end
+  end
   context ".load_policies" do
     before do
       @pid = 'duke-apo:TestPolicy'


### PR DESCRIPTION
Fixes #276.
