### PR TITLE
Define properties datastream; closes #284.

### DIFF
--- a/lib/dul_hydra/datastreams.rb
+++ b/lib/dul_hydra/datastreams.rb
@@ -6,6 +6,7 @@ module DulHydra::Datastreams
   DEFAULT_RIGHTS = "defaultRights"
   DESC_METADATA = "descMetadata"
   EVENT_METADATA = "eventMetadata"
+  PROPERTIES = "properties"
   RELS_EXT = "RELS-EXT"
   RIGHTS_METADATA = "rightsMetadata"
   THUMBNAIL = "thumbnail"

--- a/lib/dul_hydra/datastreams/properties_datastream.rb
+++ b/lib/dul_hydra/datastreams/properties_datastream.rb
@@ -1,0 +1,21 @@
+module DulHydra::Datastreams
+  
+  class PropertiesDatastream < ActiveFedora::OmDatastream
+    set_terminology do |t|
+      t.root(:path => "fields")
+      t.descmetadata_ {
+        t.source
+      }
+      
+      t.descmetadata_source(:proxy=>[:descmetadata, :source])
+    end
+    
+    def self.xml_template
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.fields
+      end
+      builder.doc
+    end
+  end
+  
+end

--- a/lib/dul_hydra/models/base.rb
+++ b/lib/dul_hydra/models/base.rb
@@ -6,6 +6,7 @@ module DulHydra::Models
     include AccessControllable
     include HasAttachments
     include HasPreservationEvents
+    include HasProperties
     include HasThumbnail
     include ActiveFedora::Auditable
 

--- a/lib/dul_hydra/models/has_properties.rb
+++ b/lib/dul_hydra/models/has_properties.rb
@@ -1,0 +1,15 @@
+module DulHydra::Models
+  module HasProperties
+    extend ActiveSupport::Concern
+    
+    included do
+      has_metadata :name => DulHydra::Datastreams::PROPERTIES, 
+                   :type => DulHydra::Datastreams::PropertiesDatastream,
+                   :versionable => true, 
+                   :label => "Properties for this object", 
+                   :control_group => 'X'
+      delegate_to DulHydra::Datastreams::PROPERTIES, [:descmetadata_source], multiple: false
+    end
+    
+  end
+end

--- a/spec/support/shared_examples_for_dul_hydra_objects.rb
+++ b/spec/support/shared_examples_for_dul_hydra_objects.rb
@@ -2,6 +2,7 @@ require 'support/shared_examples_for_describables'
 require 'support/shared_examples_for_governables'
 require 'support/shared_examples_for_access_controllables'
 require 'support/shared_examples_for_has_preservation_events'
+require 'support/shared_examples_for_has_properties'
 require 'support/shared_examples_for_has_thumbnail'
 
 shared_examples "a DulHydra object" do
@@ -10,6 +11,7 @@ shared_examples "a DulHydra object" do
   it_behaves_like "a governable object"
   it_behaves_like "an access controllable object"
   it_behaves_like "an object that has preservation events"
+  it_behaves_like "an object that has properties"
   it_behaves_like "an object that has a thumbnail"
 
   context "#title_display" do

--- a/spec/support/shared_examples_for_has_properties.rb
+++ b/spec/support/shared_examples_for_has_properties.rb
@@ -1,0 +1,5 @@
+shared_examples "an object that has properties" do
+  it "should have a properties datastream" do
+    expect(subject.datastreams.keys).to include(DulHydra::Datastreams::PROPERTIES)
+  end
+end


### PR DESCRIPTION
Define the properties datastream and include descmetadata_source as the
first defined property.
