### PR TITLE
Added redirect_after_create method to ObjectsController for customizing ...

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -31,7 +31,7 @@ class ObjectsController < ApplicationController
     # Grant edit rights to creator
     @object.permissions = [{type: "user", access: "edit", name: current_user.user_key}]
     @object.save
-    redirect_to action: :show, id: @object
+    redirect_to redirect_after_create
   rescue NameError # This is just a sanity guard against brute force
     CanCan::AccessDenied
   end
@@ -89,6 +89,15 @@ class ObjectsController < ApplicationController
   end
 
   protected
+
+  def redirect_after_create
+    case @object.class.to_s
+    when "AdminPolicy"
+      default_permissions_edit_path(@object)
+    else
+      object_path(@object)
+    end
+  end
 
   def object_preservation_events
     @object_preservation_events ||= PreservationEvent.events_for(params[:id])

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -26,10 +26,6 @@ describe ObjectsController do
         post :create, model: 'collection', object: {title: 'New Collection'}
         assigns(:object).should be_persisted
       end
-      it "should redirect to the object show page" do
-        post :create, model: 'collection', object: {title: 'New Collection'}
-        response.should redirect_to(object_path(assigns(:object)))
-      end
       it "should grant edit rights to the object creator (user)" do
         post :create, model: 'collection', object: {title: 'New Collection'}
         assigns(:object).edit_users.should include(user.user_key)
@@ -40,6 +36,20 @@ describe ObjectsController do
         it "should assign an admin policy" do
           post :create, model: 'collection', object: {title: 'New Collection', admin_policy_id: apo.pid}
           assigns(:object).admin_policy_id.should == apo.pid
+        end
+      end
+      context "after creation" do
+        context "model is AdminPolicy" do
+          it "should redirect to edit default permissions page" do
+            post :create, model: 'admin_policy', object: {title: 'New Admin Policy'}
+            response.should redirect_to(default_permissions_edit_path(assigns(:object)))
+          end
+        end
+        context "other models" do
+          it "should redirect to the object show page" do
+            post :create, model: 'collection', object: {title: 'New Collection'}
+            response.should redirect_to(object_path(assigns(:object)))
+          end
         end
       end
     end


### PR DESCRIPTION
...post-create redirect.

AdminPolicy objects redirect to default_permissions edit view after create -- fixes #417.
