### PR TITLE
Added Attachment#set_initial_permissions

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -7,7 +7,21 @@ class Attachment < DulHydra::Base
              :class_name => 'ActiveFedora::Base'
 
   validates :title, presence: true
+  # XXX With Rubydora 1.7.1 can change to
+  # validates :content, presence: true
   validates :content, has_content: true
   validates :attached_to, presence: true
+
+  def set_initial_permissions(user_creator = nil)
+    if attached_to
+      self.permissions_attributes = attached_to.permissions.collect { |p| p.vals }
+      # XXX In active-fedora 7.0 can do
+      # self.admin_policy = attached_to.admin_policy
+      self.admin_policy_id = attached_to.admin_policy_id if attached_to.has_admin_policy?
+    end
+    if user_creator
+      self.permissions_attributes = [{type: 'user', name: user_creator.user_key, access: 'edit'}]
+    end
+  end
   
 end

--- a/config/initializers/dul_hydra.rb
+++ b/config/initializers/dul_hydra.rb
@@ -2,6 +2,7 @@ require 'dul_hydra'
 require 'dul_hydra/decorators/active_fedora/base_decorator'
 require 'dul_hydra/decorators/active_fedora/datastream_decorator'
 require 'dul_hydra/decorators/blacklight/solr_helper_decorator'
+require 'dul_hydra/decorators/hydra_access_controls/permission_decorator'
 
 DulHydra.configure do |config|
   config.collection_report_fields = [:pid, :identifier, :content_size]

--- a/lib/dul_hydra/decorators/hydra_access_controls/permission_decorator.rb
+++ b/lib/dul_hydra/decorators/hydra_access_controls/permission_decorator.rb
@@ -1,0 +1,3 @@
+Hydra::AccessControls::Permission.class_eval do
+  attr_reader :vals
+end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -42,7 +42,20 @@ describe AttachmentsController, attachments: true do
         @attachment.source.should == ["sample.docx"]
         @attachment.content.size.should == File.size('spec/fixtures/sample.docx')
         @attachment.attached_to.should == obj
+        @attachment.permissions.should == obj.permissions
         response.should redirect_to(controller: 'objects', action: 'show', id: obj, tab: 'attachments')
+      end
+      context "attached_to object is governed by an admin policy" do
+        let(:apo) { FactoryGirl.create(:admin_policy) }
+        before do
+          obj.admin_policy = apo
+          obj.save!
+        end
+        after { apo.destroy }
+        it "should set the admin policy of the attachment to the object's admin policy" do
+          post :create, id: obj, attachment: {title: "Attachment", description: "Sample file"}, content: fixture_file_upload('sample.docx')
+          assigns(:attachment).admin_policy.should == apo
+        end
       end
     end
     describe "user cannot add attachments to object" do


### PR DESCRIPTION
Monkey patched Hydra::AccessControls::Permission to make it easier to extract the perms hash
AttachmentsController#create copies permissions and admin policy from attached_to object
Fixes #560
