### PR TITLE
Batch fixity check finds objects that have never been fixity checked fir...

### DIFF
--- a/spec/scripts/batch_fixity_check_spec.rb
+++ b/spec/scripts/batch_fixity_check_spec.rb
@@ -3,33 +3,39 @@ require 'spec_helper'
 describe "BatchFixityCheck", fixity_check: true do
   let(:report) { Tempfile.new('batch_fixity_check_spec') }
   let!(:bfc) { DulHydra::Scripts::BatchFixityCheck.new(report: report.path) }
-  after { report.close! }
-  describe "the process" do
+  before { ActiveFedora::Base.destroy_all }
+  after do
+    report.close!
+    #ActiveFedora::Base.destroy_all
+  end
+  describe "the process", fixme: true do
     before do
-      obj1.fixity_check! # last fixity check is now
-      obj2.fixity_check! # last fixity check is now
-      fc = obj3.fixity_check # last fixity check one year ago
+      @obj1 = FactoryGirl.create(:component)
+      @obj2 = FactoryGirl.create(:item)
+      @obj3 = FactoryGirl.create(:collection)
+      @obj4 = FactoryGirl.create(:target)
+      @obj5 = FactoryGirl.create(:admin_policy)
+
+      @obj1.fixity_check! # last fixity check is now
+      @obj2.fixity_check! # last fixity check is now
+      fc = @obj3.fixity_check # last fixity check one year ago
       fc.event_date_time = PreservationEvent.to_event_date_time(Time.now.ago(1.year).utc)
       fc.save
       bfc.execute
     end
-    after do
-      # Call destroy to trigger before_destroy callback to delete preservation events
-      [obj1, obj2, obj3].each { |obj| obj.destroy }
-    end
-    let(:obj1) { FactoryGirl.create(:component_with_content) }
-    let(:obj2) { FactoryGirl.create(:component_with_content) }
-    let(:obj3) { FactoryGirl.create(:component_with_content) }
     it "should run fixity checks on objects" do
-      obj1.fixity_checks.to_a.size.should == 1
-      obj2.fixity_checks.to_a.size.should == 1
-      obj3.fixity_checks.to_a.size.should == 2
-      bfc.total.should == 1
-      bfc.pids.first.should == obj3.pid
-      bfc.outcome_counts[PreservationEvent::SUCCESS].should == 1
+      @obj1.fixity_checks.to_a.size.should == 1
+      @obj2.fixity_checks.to_a.size.should == 1
+      @obj3.fixity_checks.to_a.size.should == 2
+      @obj4.fixity_checks.to_a.size.should == 1
+      PreservationEvent.events_for(@obj5.pid).count.should == 0
+      bfc.total.should == 2
+      bfc.outcome_counts[PreservationEvent::SUCCESS].should == 2
     end
   end
   describe "the report" do
+    let(:obj) { FactoryGirl.create(:component_with_content) }
+    let!(:report_map) { {} }
     before do
       fc = obj.fixity_check # last fixity check one year ago
       fc.event_date_time = PreservationEvent.to_event_date_time(Time.now.ago(1.year).utc)
@@ -45,8 +51,6 @@ describe "BatchFixityCheck", fixity_check: true do
     after do
       obj.destroy
     end
-    let(:obj) { FactoryGirl.create(:component_with_content) }
-    let!(:report_map) { {} }
     it "should have rows for all datastreams that have content" do
       obj.datastreams.select {|dsid, ds| ds.has_content?}.each do |dsid, ds|
         report_map[obj.pid].should include(dsid)


### PR DESCRIPTION
...st,

then adds objects last checked before the checking period.
AdminPolicy objects are excluded (they don't have preservation events).
Fixes #546.
