### PR TITLE
attachment initial permissions now conform to initial object permissions...

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -14,10 +14,13 @@ class Attachment < DulHydra::Base
 
   def set_initial_permissions(user_creator = nil)
     if attached_to
-      self.permissions_attributes = attached_to.permissions.collect { |p| p.vals }
-      # XXX In active-fedora 7.0 can do
-      # self.admin_policy = attached_to.admin_policy
-      self.admin_policy_id = attached_to.admin_policy_id if attached_to.has_admin_policy?
+      if attached_to.has_admin_policy?
+        # XXX In active-fedora 7.0 can do
+        # self.admin_policy = attached_to.admin_policy
+        self.admin_policy_id = attached_to.admin_policy_id
+      else      
+        self.permissions_attributes = attached_to.permissions.collect { |p| p.vals }
+      end
     end
     if user_creator
       self.permissions_attributes = [{type: 'user', name: user_creator.user_key, access: 'edit'}]

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -55,5 +55,55 @@ describe Attachment, attachments: true do
       subject.errors.messages.should have_key(:attached_to)
     end
   end
+  context "#set_initial_permissions" do
+    let(:attachment) { FactoryGirl.build(:attached_attachment) }
+    after { attachment.attached_to.destroy }
+    context "attached to object with admin policy" do
+      let(:apo) { FactoryGirl.create(:admin_policy) }
+      before do
+        attachment.attached_to.admin_policy = apo
+        attachment.set_initial_permissions
+      end
+      after { apo.destroy }
+      it "should have the attached to object's admin policy" do
+        expect(attachment.admin_policy).to eq(apo)        
+      end
+      context "attached to object with individual permissions" do
+        let(:permissions_attributes) { [ { type: 'user', name: 'person1', access: 'read' } ] }
+        before do
+          attachment.attached_to.permissions_attributes = permissions_attributes
+          attachment.set_initial_permissions
+        end
+        it "should have no individual permissions" do
+          expect(attachment.permissions).to be_empty
+        end
+      end
+      context "attached to object without individual permissions" do
+        it "should have no individual permissions" do
+          expect(attachment.permissions).to be_empty
+        end
+      end
+    end
+    context "attached to object without admin policy" do
+      it "should not have an admin policy" do
+        expect(attachment.admin_policy).to be_nil        
+      end
+      context "attached to object with individual permissions" do
+        let(:permissions_attributes) { [ { type: 'user', name: 'person1', access: 'read' } ] }
+        before do
+          attachment.attached_to.permissions_attributes = permissions_attributes
+          attachment.set_initial_permissions
+        end
+        it "should have no admin policy and the attached to object's individual permissions" do
+          expect(attachment.permissions).to eq(attachment.attached_to.permissions)
+        end
+      end
+      context "attached to object without individual permissions" do
+        it "should have no admin policy and no individual permissions" do
+          expect(attachment.permissions).to be_empty
+        end          
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
... policy; closes #606
