### PR TITLE
Override #gated_discovery_filters in ApplicationController (included fro...

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,12 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  # Override Hydra::PolicyAwareAccessControlsEnforcement
+  def gated_discovery_filters
+    return [] if current_user.superuser?
+    super
+  end
+
   def configure_permitted_parameters
       devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:username, :email, :password, :password_confirmation, :remember_me) }
       devise_parameter_sanitizer.for(:sign_in) { |u| u.permit(:username, :email, :password, :remember_me) }

--- a/spec/features/catalog/index.html.erb_spec.rb
+++ b/spec/features/catalog/index.html.erb_spec.rb
@@ -65,5 +65,16 @@ describe "catalog/index.html.erb" do
         page.should have_xpath("//a[@href = \"#{download_object_path(object)}\"]")
       end
     end
+    context "user is superuser" do
+      before do
+        User.any_instance.stub(:superuser?).and_return(true)
+        visit catalog_index_path
+        fill_in "q", :with => object.title.first
+        click_button "search"
+      end
+      it "should discover the object" do
+        page.should have_content(object.pid)
+      end
+    end
   end
 end


### PR DESCRIPTION
...m Hydra::PolicyAwareAccessControlsEnforcement) to return empty array if current user is superuser.

Fixes #578
