### PR TITLE
Added original_filename property (fixes #693)

### DIFF
--- a/app/controllers/concerns/dul_hydra/upload_behavior.rb
+++ b/app/controllers/concerns/dul_hydra/upload_behavior.rb
@@ -5,8 +5,7 @@ module DulHydra
       file = params.require(:content)
       obj.content.content = file
       obj.content.mimeType = file.content_type
-      obj.source = file.original_filename
-      obj.set_thumbnail if opts[:thumbnail]
+      obj.original_filename = file.original_filename
     end
 
   end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -14,7 +14,7 @@ class UploadsController < ApplicationController
   end
 
   def update
-    upload current_object, thumbnail: true
+    upload current_object
     if current_object.save
       log_event
       flash[:notice] = "Content successfully uploaded."

--- a/app/models/concerns/dul_hydra/governable.rb
+++ b/app/models/concerns/dul_hydra/governable.rb
@@ -33,7 +33,7 @@ module DulHydra
     def copy_admin_policy_from(other)
       # XXX In active-fedora 7.0 can do
       # self.admin_policy = other.admin_policy
-      admin_policy_id = other.admin_policy_id if other.has_admin_policy?
+      self.admin_policy_id = other.admin_policy_id if other.has_admin_policy?
     end
 
   end

--- a/app/models/concerns/dul_hydra/has_content.rb
+++ b/app/models/concerns/dul_hydra/has_content.rb
@@ -3,13 +3,16 @@ module DulHydra
     extend ActiveSupport::Concern
 
     included do
-      has_file_datastream :name => DulHydra::Datastreams::CONTENT, 
-                          :type => DulHydra::Datastreams::FileContentDatastream,
-                          :versionable => true, 
-                          :label => "Content file for this object", 
-                          :control_group => 'M'
+      has_file_datastream name: DulHydra::Datastreams::CONTENT, 
+                          type: DulHydra::Datastreams::FileContentDatastream,
+                          versionable: true, 
+                          label: "Content file for this object", 
+                          control_group: 'M'
 
       include Hydra::Derivatives
+
+      # Original file name of content file should be stored in this property
+      has_attributes :original_filename, datastream: DulHydra::Datastreams::PROPERTIES, multiple: false
     end
 
     def content_type
@@ -18,13 +21,14 @@ module DulHydra
 
     def set_thumbnail
       set_thumbnail_from_content
+    end      
+
+    def image?
+      content_type =~ /image\//
     end
 
-    def terms_for_editing
-      terms = super
-      terms.delete(:source) # source is reserved for original file name
-      terms
+    def pdf?
+      content_type == "application/pdf"
     end
-      
   end
 end

--- a/app/models/concerns/dul_hydra/has_properties.rb
+++ b/app/models/concerns/dul_hydra/has_properties.rb
@@ -3,12 +3,11 @@ module DulHydra
     extend ActiveSupport::Concern
     
     included do
-      has_metadata :name => DulHydra::Datastreams::PROPERTIES, 
-                   :type => DulHydra::Datastreams::PropertiesDatastream,
-                   :versionable => true, 
-                   :label => "Properties for this object", 
-                   :control_group => 'X'
-      has_attributes :descmetadata_source, datastream: DulHydra::Datastreams::PROPERTIES, multiple: false
+      has_metadata name: DulHydra::Datastreams::PROPERTIES, 
+                   type: DulHydra::Datastreams::PropertiesDatastream,
+                   versionable: true, 
+                   label: "Properties for this object", 
+                   control_group: 'M'
     end
     
   end

--- a/app/models/concerns/dul_hydra/has_thumbnail.rb
+++ b/app/models/concerns/dul_hydra/has_thumbnail.rb
@@ -31,7 +31,9 @@ module DulHydra
 
     def set_thumbnail_from_content
       if has_content?
-        transform_datastream :content, { thumbnail: { size: "100x100>", datastream: "thumbnail" } }
+        if image? or pdf?
+          transform_datastream :content, { thumbnail: { size: "100x100>", datastream: "thumbnail" } }
+        end
       end
     end
 

--- a/app/models/dul_hydra/base.rb
+++ b/app/models/dul_hydra/base.rb
@@ -43,5 +43,9 @@ module DulHydra
       [outcome, results]
     end
 
+    def copy_admin_policy_or_permissions_from(other)
+      copy_permissions_from(other) unless copy_admin_policy_from(other)
+    end
+
   end
 end

--- a/lib/dul_hydra/datastreams/properties_datastream.rb
+++ b/lib/dul_hydra/datastreams/properties_datastream.rb
@@ -1,21 +1,19 @@
-module DulHydra::Datastreams
-  
-  class PropertiesDatastream < ActiveFedora::OmDatastream
-    set_terminology do |t|
-      t.root(:path => "fields")
-      t.descmetadata_ {
-        t.source
-      }
-      
-      t.descmetadata_source(:proxy=>[:descmetadata, :source])
-    end
-    
-    def self.xml_template
-      builder = Nokogiri::XML::Builder.new do |xml|
-        xml.fields
+module DulHydra
+  module Datastreams  
+    class PropertiesDatastream < ActiveFedora::OmDatastream
+
+      set_terminology do |t|
+        t.root(:path => "fields")
+        t.original_filename
       end
-      builder.doc
+      
+      def self.xml_template
+        builder = Nokogiri::XML::Builder.new do |xml|
+          xml.fields
+        end
+        builder.doc
+      end
+
     end
   end
-  
 end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -29,21 +29,17 @@ describe UploadsController, uploads: true do
       before do
         object.edit_users = [user.user_key]
         object.save!
-      end
-      it "should upload the content" do
         patch :update, id: object, content: fixture_file_upload('sample.pdf', 'application/pdf'), comment: "Corrected version"
         object.reload
-        expect(object.source).to eq(['sample.pdf'])
+      end
+      it "should upload the content" do
         expect(object.content.size).to eq(83777)
         expect(object.content.mimeType).to eq("application/pdf")
       end
-      it "should update the thumbnail" do
-        patch :update, id: object, content: fixture_file_upload('sample.pdf', 'application/pdf'), comment: "Corrected version"
-        object.reload
-        expect(object.thumbnail.mimeType).to eq("image/png")
+      it "should store the original file name in a property" do
+        expect(object.original_filename).to eq("sample.pdf")
       end
       it "should create an event log" do
-        patch :update, id: object, content: fixture_file_upload('sample.pdf'), comment: "Corrected version"
         expect(object.event_logs.count).to eq(1)
         expect(object.event_logs.first.comment).to eq("Corrected version")
       end

--- a/spec/models/has_content_spec.rb
+++ b/spec/models/has_content_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe DulHydra::HasContent do
+  let(:obj) { FactoryGirl.build(:test_content) }
+  it "should have a content_type" do
+    obj.content.stub(:mimeType).and_return("image/tiff")
+    expect(obj.content_type).to eq("image/tiff")
+  end
+  context "should respond_to :image?" do
+    it "when it's an image" do
+      obj.stub(:content_type).and_return("image/png")
+      expect(obj.image?).to be_true
+    end
+    it "when it's a non-image type" do
+      obj.stub(:content_type).and_return("application/pdf")
+      expect(obj.image?).to be_false
+    end
+    it "when content_type is nil" do
+      obj.stub(:content_type).and_return(nil)
+      expect(obj.image?).to be_false
+    end
+  end
+  context "should respond_to :pdf?" do
+    it "when it's an image" do
+      obj.stub(:content_type).and_return("image/png")
+      expect(obj.pdf?).to be_false
+    end
+    it "when it's a PDF" do
+      obj.stub(:content_type).and_return("application/pdf")
+      expect(obj.pdf?).to be_true
+    end
+    it "when content_type is nil" do
+      obj.stub(:content_type).and_return(nil)
+      expect(obj.pdf?).to be_false
+    end
+  end
+end

--- a/spec/support/shared_examples_for_describables.rb
+++ b/spec/support/shared_examples_for_describables.rb
@@ -12,20 +12,4 @@ shared_examples "a describable object" do
       described_class.find_by_identifier('id001').should include(object)
     end
   end
-  context "descriptive metadata source" do
-    context "present in properties" do
-      before do
-        object.descmetadata_source = 'some_value'
-        object.save(validate: false)
-      end
-      it "should indicate that descriptive metadata is not editable" do
-        object.descriptive_metadata_editable?.should eql(false)
-      end
-    end
-    context "not present in properties" do
-      it "should indicate that descriptive metadata is editable" do
-        object.descriptive_metadata_editable?.should eql(true)        
-      end      
-    end
-  end
 end


### PR DESCRIPTION
Removed descmetadata_source property (fixes #696)
Changes properties datastream to be managed instead of inline XML (fixes #695)
