### PR TITLE
Upgraded devise-remote-user to v0.3.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'blacklight', '4.7.0'
 gem 'bootstrap-sass' # blacklight 4.0
 gem 'unicode'        # blacklight 4.0
 gem 'devise', '~> 3.1.1'
-gem 'devise-remote-user', '0.2.0'
+gem 'devise-remote-user', '0.3.0'
 gem 'active-fedora', '6.7.6'
 gem 'grouper-rest-client'
 gem 'hydra-editor', '0.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,9 +81,9 @@ GEM
       railties (>= 3.2.6, < 5)
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
-    devise-remote-user (0.2.0)
+    devise-remote-user (0.3.0)
       devise
-      rails (>= 3.2)
+      rails (>= 3.2, < 5.0)
     diff-lcs (1.2.5)
     ensure_valid_encoding (0.5.3)
     equivalent-xml (0.4.0)
@@ -298,7 +298,7 @@ DEPENDENCIES
   delayed_job_active_record
   deprecation
   devise (~> 3.1.1)
-  devise-remote-user (= 0.2.0)
+  devise-remote-user (= 0.3.0)
   factory_girl_rails (~> 4.0)
   grouper-rest-client
   hydra-derivatives

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   include Blacklight::Controller
   include Hydra::Controller::ControllerBehavior
   include Hydra::PolicyAwareAccessControlsEnforcement
+  include DeviseRemoteUser::ControllerBehavior
 
   protect_from_forgery
 
@@ -142,11 +143,4 @@ class ApplicationController < ActionController::Base
     end
   end
   
-  private
-  
-  # Cf. https://github.com/plataformatec/devise/wiki/How-To:-Change-the-redirect-path-after-destroying-a-session-i.e.-signing-out
-  def after_sign_out_path_for(resource_or_scope)
-    "/Shibboleth.sso/Logout?return=https://shib.oit.duke.edu/cgi-bin/logout.pl"
-  end
-
 end

--- a/config/initializers/dul_hydra.rb
+++ b/config/initializers/dul_hydra.rb
@@ -51,6 +51,7 @@ DeviseRemoteUser.configure do |config|
     display_name: 'displayName'
   }
   config.auto_update = true
+  config.logout_url = "/Shibboleth.sso/Logout?return=https://shib.oit.duke.edu/cgi-bin/logout.pl"
 end
 
 # Integration of remote (Grouper) groups via Shibboleth


### PR DESCRIPTION
Added DeviseRemoteUser.logout_url setting
Removed #after_sign_out_path_for from ApplicationController.
Included DeviseRemoteUser::ControllerBehavior in ApplicationController.
