### PR TITLE
Added `can? :create, Item` guard on "Add Item" link (fixes #776)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -246,7 +246,7 @@ module ApplicationHelper
   end
 
   def create_menu_models
-    current_ability.can_create_models.reject { |m| m == "Attachment" }
+    current_ability.can_create_models & ["AdminPolicy", "Collection"]
   end
 
   def cancel_button

--- a/app/views/application/_tools.html.erb
+++ b/app/views/application/_tools.html.erb
@@ -4,21 +4,21 @@
     <li>
 	  <%= render_show_doc_actions current_document %>
     </li>
-	<% if current_object.is_a?(Collection) and can?(:add_children, current_object) %>
+	<% if current_object.is_a?(Collection) and can?(:create, Item) and can?(:add_children, current_object) %>
 	  <li>
 		<%= link_to new_item_path(current_object) do %>
 		  <i class="icon-plus"></i> Add Item
 		<% end %>
 	  </li>
 	<% end %>
-	<% if current_object.is_a?(Item) and can?(:add_children, current_object) %>
+	<% if current_object.is_a?(Item) and can?(:create, Component) and can?(:add_children, current_object) %>
 	  <li>
 		<%= link_to new_component_path(current_object) do %>
 		  <i class="icon-plus"></i> Add Component
 		<% end %>
 	  </li>
 	<% end %>
-	<% if current_object.can_have_attachments? and can?(:add_attachment, current_object) %>
+	<% if current_object.can_have_attachments? and can?(:create, Attachment) and can?(:add_attachment, current_object) %>
 	  <li>
 		<%= link_to new_attachment_path(current_object) do %>
 		  <%= image_tag "silk/attach.png", size: "16x16", alt: "attach" %>


### PR DESCRIPTION
Added `can? :create, Attachment` guard on "Add Attachment" link
Added `can? :create, Component` guard on "Add Component" link
Limited create menu options to AdminPolicy and Collection
