### PR TITLE
Antivirus service checks whether reload of db is necessary before each s...

### DIFF
--- a/spec/services/antivirus_spec.rb
+++ b/spec/services/antivirus_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe DulHydra::Services::Antivirus, antivirus: true do
   let(:file) { fixture_file_upload "library-devil.tiff" }
+  it "should reload the db" do
+    expect(described_class).to receive(:reload!)
+    described_class.scan file
+  end
   it "should report whether a file is infected" do
     expect(described_class.scan(file)).not_to have_virus
   end


### PR DESCRIPTION
...can.

Note that ClamAV's ruby bindings break when a reload is necessary, so we have
to rescue from a RuntimeError and do a loaddb.
Fixes #935
