### PR TITLE
Report dsCreateDate in local time (not UTC) in batch fixity check report

### DIFF
--- a/lib/dul_hydra/scripts/batch_fixity_check.rb
+++ b/lib/dul_hydra/scripts/batch_fixity_check.rb
@@ -107,7 +107,7 @@ module DulHydra
             report << [result.pid,
                        dsid,
                        profile["dsVersionID"],
-                       profile["dsCreateDate"],
+                       profile["dsCreateDate"].localtime,
                        profile["dsChecksumType"],
                        profile["dsChecksum"],
                        profile["dsChecksumValid"]

--- a/spec/scripts/batch_fixity_check_spec.rb
+++ b/spec/scripts/batch_fixity_check_spec.rb
@@ -50,7 +50,9 @@ module DulHydra
             expect(row["PID"]).to match(/^[a-z]+:\d+$/)
             expect(datastreams_with_content).to include(row["Datastream"])
             expect(row["dsVersionID"]).to match(/^#{row["Datastream"]}/)
-            expect(DateTime.parse(row["dsCreateDate"])).to be_a(DateTime)
+            createDate = Time.parse(row["dsCreateDate"])
+            expect(createDate).to be_a Time
+            expect(createDate).to_not be_utc
             expect(row["dsChecksumType"]).to eq("SHA-256")
             expect(row["dsChecksum"]).to match(/^\h{64}$/)
             expect(row["dsChecksumValid"]).to match(/^(true|false)$/)


### PR DESCRIPTION
Fixes #545
