### PR TITLE
Parent or attached_to object pid now in hidden field in new object forms

### DIFF
--- a/app/views/application/_parent_field.html.erb
+++ b/app/views/application/_parent_field.html.erb
@@ -1,0 +1,5 @@
+<div class="form-group">
+  <%= label_tag :parent_id, label %>
+  <%= link_to parent.title_display, url_for(parent) %>
+  <%= hidden_field_tag :parent_id, parent.pid %>
+</div>

--- a/app/views/attachments/new.html.erb
+++ b/app/views/attachments/new.html.erb
@@ -1,8 +1,9 @@
 <div class="form-group">
   <%= label_tag :attached_to_id, "Attached To" %>
   <%= link_to attached_to.title_display, url_for(attached_to) %>
-  <%= text_field_tag :attached_to_id, attached_to.pid, readonly: "readonly", class: "form-control" %>
+  <%= hidden_field_tag :attached_to_id, attached_to.pid %>
 </div>
 
 <%= render 'title_field' %>
+
 <%= render 'select_content_file' %>

--- a/app/views/components/new.html.erb
+++ b/app/views/components/new.html.erb
@@ -3,11 +3,7 @@
   <span class="formn-control-static"><%= link_to collection.title_display, url_for(collection) %></span>
 </div>
 
-<div class="form-group">
-  <%= label_tag :parent_id, "Part of Item" %> 
-  <%= link_to parent.title_display, url_for(parent) %>
-  <%= text_field_tag :parent_id, parent.pid, readonly: "readonly", class: "form-control" %>
-</div>
+<%= render partial: 'parent_field', locals: {label: "Part of Item"} %>
 
 <%= render 'select_content_file' %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,9 +1,13 @@
-<div class="form-group">
-  <%= label_tag :parent_id, "Member of Collection" %>
-  <%= link_to parent.title_display, url_for(parent) %>
-  <%= text_field_tag :parent_id, parent.pid, readonly: "readonly", class: "form-control" %>
-</div>
+<%= render partial: 'parent_field', locals: {label: "Member of Collection"} %>
 
-<h4><span class="glyphicon glyphicon-plus"></span> Component <small>Optional</small></h4>
-<p class="text-muted">You can also add (more) components to the new item later.</p>
+<h4>
+  <span class="glyphicon glyphicon-plus"></span> 
+  Component 
+  <small>Optional</small>
+</h4>
+
+<p class="text-muted">
+  You can also add (more) components to the new item later.
+</p>
+
 <%= render 'select_content_file' %>


### PR DESCRIPTION
Fixes #1127
