### PR TITLE
Changes default external file naming to use the UUID as the file name.

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -9,10 +9,7 @@ class DownloadsController < ApplicationController
   end
 
   def datastream_name
-    if datastream.external?
-      file_path = DulHydra::Utils.path_from_uri(datastream.dsLocation)
-      return File.basename(file_path)
-    elsif datastream.dsid == DulHydra::Datastreams::CONTENT
+    if datastream.dsid == DulHydra::Datastreams::CONTENT
       return asset.original_filename if asset.original_filename.present?
       if asset.identifier.present? # Identifier may be file name minus extension
         identifier = asset.identifier.first

--- a/app/models/concerns/dul_hydra/file_management.rb
+++ b/app/models/concerns/dul_hydra/file_management.rb
@@ -18,50 +18,73 @@ module DulHydra
       around_destroy :cleanup_external_files_on_destroy
     end
 
-    # Comparable to Hydra::ModelMethods method add_file(file, dsid, file_name)
+    # add_file(file, dsid, opts={})
+    #
+    # Comparable to Hydra::ModelMethods#add_file(file, dsid, file_name)
+    #
+    # Options:
+    #
+    #   :mime_type - Explicit mime type to set (otherwise discerned from file path or name)
+    #
+    #   :original_name - A String value will be understood as the original name of the file.
+    #                    `false` or `nil` indicate that the file basename is not the original 
+    #                    name. Default processing will take the file basename as the original 
+    #                    name.
+    #
+    #   :external - Add to file to external datastream. Not required for datastream specs
+    #               where :control_group=>"E".
+    #
+    #   :use_original - For external datastream file, do not copy file to new file path,
+    #                   but use in place (set dsLocation to file URI for current path.
     def add_file file, dsid, opts={}
-      self.file_to_add = file
+      opts[:mime_type] ||= DulHydra::Utils.mime_type_for(file)
 
-      opts[:file_name] ||= DulHydra::Utils.file_name_for(file)
-      opts[:mime_type] ||= DulHydra::Utils.mime_type_for(file, opts[:file_name])
+      # @file_to_add is set for callbacks to access the data
+      original_name = opts.fetch(:original_name, DulHydra::Utils.file_name_for(file))
+      self.file_to_add = FileToAdd.new(file, dsid, original_name)
 
       run_callbacks(:add_file) do
         if opts.delete(:external) || datastreams.include?(dsid) && datastreams[dsid].external?
           add_external_file(file, dsid, opts)
         else
-          # ActiveFedora method
-          add_file_datastream(file, dsid: dsid, mimeType: opts[:mime_type])
+          file = File.new(file, "rb") if DulHydra::Utils.file_path?(file)
+          # ActiveFedora method accepts file-like objects, not paths
+          add_file_datastream(file, dsid: dsid, mimeType: opts[:mime_type]) 
         end
       end
 
+      # clear the instance data
       self.file_to_add = nil
     end
 
-    # Normally this method should not be called directly
-    # Call #add_file with dsid for external datastream id, or :external => true if no spec for dsid
+    # Normally this method should not be called directly. Call `add_file` with dsid for 
+    # external datastream id, or with `:external=>true` option if no spec for dsid.
     def add_external_file file, dsid, opts={}
       file_path = DulHydra::Utils.file_path(file) # raises ArgumentError
 
       # Retrieve or create the datastream
       ds = datastreams.include?(dsid) ? datastreams[dsid] : add_external_datastream(dsid)
 
-      raise ArgumentError, "Cannot add external file to datastream with controlGroup \"#{ds.controlGroup}\": #{ds.inspect}" unless ds.external?
+      unless ds.external?
+        raise ArgumentError, "Cannot add external file to datastream with controlGroup \"#{ds.controlGroup}\"" 
+      end
 
-      raise DulHydra::Error, "Cannot add external file to datastream when dsLocation change is pending." if ds.dsLocation_changed?
+      if ds.dsLocation_changed?
+        raise DulHydra::Error, "Cannot add external file to datastream when dsLocation change is pending."
+      end
 
-      # set the mime type
-      # the :mime_type option will be set when called from #add_file
-      # the fallback is there in case #add_external_file is called directly
+      # Set the MIME type
+      # The :mime_type option will be present when called from `add_file`.
+      # The fallback is there in case `add_external_file` is called directly.
       ds.mimeType = opts[:mime_type] || DulHydra::Utils.mime_type_for(file, file_path)
 
-      # copy the file to storage unless we're using the original
+      # Copy the file to storage unless we're using the original
       if opts[:use_original]
         raise DulHydra::Error, "Cannot add file to repository that is owned by another user." unless File.owned?(file_path)
         store_path = file_path
       else
-        # generate storage path
-        file_name = opts[:file_name] || DulHydra::Utils.file_name_for(file)
-        store_path = File.join(create_external_directory!, file_name)
+        # generate new storage path for file
+        store_path = create_external_file_path!
         # copy the original file to the storage location
         FileUtils.cp file_path, store_path
       end
@@ -69,21 +92,25 @@ module DulHydra
       # set appropriate permissions on the file
       set_external_file_permissions!(store_path)
 
+      # set dsLocation to file URI for storage path
       ds.dsLocation = DulHydra::Utils.path_to_uri(store_path)
     end
 
-    def create_external_directory!
-      created = FileUtils.mkdir_p(generate_external_directory_path)
-      created.first
+    # Create directory (if necessary) for newly generated file path and return path
+    def create_external_file_path!
+      file_path = generate_external_file_path
+      FileUtils.mkdir_p(File.dirname(file_path))
+      file_path
     end
 
     #
-    # Generates a new directory storage location
+    # Generates a new external file storage location
     #
     # => {external_file_store}/1/e/69/1e691815-0631-4f9b-8e23-2dfb2eec9c70
     #
-    def generate_external_directory_path
-      File.join(external_file_store, generate_external_directory_subpath)
+    def generate_external_file_path
+      file_name = generate_external_file_name
+      File.join(external_file_store, generate_external_directory_subpath(file_name), file_name)
     end
 
     def external_datastreams
@@ -104,13 +131,16 @@ module DulHydra
 
     protected
 
+    FileToAdd = Struct.new(:file, :dsid, :original_name)
+
     def virus_scan_results
       @virus_scan_results ||= []
     end
 
     def virus_scan
-      if DulHydra::Utils.file_or_path?(file_to_add) # can't virus scan blob
-        virus_scan_results << DulHydra::Services::Antivirus.scan(file_to_add) 
+      file = file_to_add[:file]
+      if DulHydra::Utils.file_or_path?(file) # can't virus scan blob
+        virus_scan_results << DulHydra::Services::Antivirus.scan(file) 
       end
     end
 
@@ -128,15 +158,14 @@ module DulHydra
       File.chmod(EXTERNAL_FILE_PERMISSIONS, file_path)
     end
 
-    def generate_external_directory_name
+    def generate_external_file_name
       SecureRandom.uuid      
     end
 
-    def generate_external_directory_subpath 
-      dirname = generate_external_directory_name
-      m = DulHydra.external_file_subpath_regexp.match(dirname)
+    def generate_external_directory_subpath(file_name)
+      m = DulHydra.external_file_subpath_regexp.match(file_name)
+      raise "File name does not match external file subpath pattern: #{file_name}" unless m
       subpath_segments = m.to_a[1..-1]
-      subpath_segments << dirname
       File.join *subpath_segments
     end
 


### PR DESCRIPTION
Original file name is saved in original_filename property.

The change was made because using original file names are unpredictable and may be
undesirable. Non-roman characters, spaces, etc. may cause problems; also in some
cases there could be a privacy or security concern in exposing the file name.
