### PR TITLE
Make ApplicationController#find_models_with_gated_discovery use Blacklig...

### DIFF
--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "3.1.8"
+  VERSION = "3.1.9"
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+RSpec.describe ApplicationController, type: :controller do
+
+  let(:user) { FactoryGirl.create(:user) }
+  before { sign_in user }
+
+  describe "#find_models_with_gated_discovery" do
+    let(:model) { Collection }
+    let(:collection1) { Collection.create(pid: "test:1", title: [ "Collection 1" ]) }
+    let(:collection2) { Collection.create(pid: "test:2", title: [ "Collection 2" ]) }
+    before do
+      collection2.permissions_attributes = [{type: "user", access: "read", name: user.user_key}]
+      collection2.save! 
+    end
+    it "should use Blacklight to query solr" do
+      expect(controller.send(:find_models_with_gated_discovery, model).to_a).to eq([ collection2 ])
+    end
+  end
+
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+
+  describe "#model_options_for_select" do
+    context "access option" do
+      let(:collection1) { Collection.new(pid: 'test:1', title: [ 'Collection 1' ]) }
+      let(:collection2) { Collection.new(pid: 'test:2', title: [ 'Collection 2' ]) }
+      before do
+        allow(helper).to receive(:can?).with(:edit, collection1) { true }
+        allow(helper).to receive(:can?).with(:edit, collection2) { false }
+        allow(helper).to receive(:find_models_with_gated_discovery) { [ collection1, collection2 ] }
+      end
+      it "should return the model objects to which user has appropriate access" do
+        expect(helper.model_options_for_select(Collection, access: :edit)).to match(/Collection 1/)
+        expect(helper.model_options_for_select(Collection, access: :edit)).to_not match(/Collection 2/)
+      end
+    end
+  end
+  
+end


### PR DESCRIPTION
...ht

to query solr instead of ActiveFedora::SolrService so we use use POST
and workaround GET request URL length limitations.