### PR TITLE
Moves addition of `:add_access_controls_to_solr_params` to `solr_search_params_logic`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,9 @@ class ApplicationController < ActionController::Base
   include Hydra::Controller::ControllerBehavior
   include Hydra::PolicyAwareAccessControlsEnforcement
 
+  # This applies appropriate access controls to all Blacklight solr queries
+  self.solr_search_params_logic += [:add_access_controls_to_solr_params]
+
   protect_from_forgery
 
   before_action :authenticate_user!

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,9 +14,6 @@ class CatalogController < ApplicationController
 
   layout 'blacklight'
 
-  # This applies appropriate access controls to all solr queries
-  CatalogController.solr_search_params_logic += [:add_access_controls_to_solr_params]
-
   configure_blacklight do |config|
 
     config.default_solr_params = {

--- a/spec/support/shared_examples_for_repository_controllers.rb
+++ b/spec/support/shared_examples_for_repository_controllers.rb
@@ -20,6 +20,10 @@ end
 
 shared_examples "a repository object controller" do
 
+  it "should add accesscontrols to solr params" do
+    expect(described_class.solr_search_params_logic).to include(:add_access_controls_to_solr_params)
+  end
+
   describe "#events" do
     let(:object) { FactoryGirl.create(object_symbol) }
     before { controller.current_ability.can(:read, object) }


### PR DESCRIPTION
From CatalogController to ApplicationController, so applies to
all repository object controllers.
Fixes #1327