### PR TITLE
Restrict installation of therubyracer to production as a workaround

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'resque-pool', '0.3.0'
 gem 'nest', '1.1.2'
 
 # ExecJS runtime
-gem 'therubyracer', '~> 0.11.3', :require => 'v8'
+gem 'therubyracer', '~> 0.11.3', require: 'v8', group: :production
 
 # For mapping file extensions to MIME types
 gem 'mime-types', '~> 1.19'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,3 +443,6 @@ DEPENDENCIES
   sqlite3
   therubyracer (~> 0.11.3)
   uglifier (~> 1.3.0)
+
+BUNDLED WITH
+   1.10.2


### PR DESCRIPTION
of OSX gcc version headaches.