### PR TITLE
File parameter missing exception caught and message set in flash.now

### DIFF
--- a/app/views/application/_form_actions.html.erb
+++ b/app/views/application/_form_actions.html.erb
@@ -3,5 +3,7 @@
   <%= f.submit class: "btn btn-primary form-action-submit", "data-loading-text" => "Submitted ..." %>
 </div>
 <script type="text/javascript">
-  $('.form-action-submit').click(function () { $(this).button('loading'); });
+  $('.form-action-submit').closest('form').submit(function () {
+    $(this).find('.form-action-submit').button('loading');
+  });
 </script>

--- a/app/views/application/_select_content_file.html.erb
+++ b/app/views/application/_select_content_file.html.erb
@@ -4,17 +4,17 @@
 </div>
 <div class="row">
   <div class="col-md-3">
-	<div class="form-group">
-	<%= label_tag "content_checksum_type", "Checksum Type" %>
-	<%= select_tag "content[checksum_type]", options_for_select(Ddr::Datastreams::CHECKSUM_TYPES, "SHA-256"), class: "form-control" %>
-	</div>
+    <div class="form-group">
+      <%= label_tag "content_checksum_type", "Checksum Type" %>
+      <%= select_tag "content[checksum_type]", options_for_select(Ddr::Datastreams::CHECKSUM_TYPES, "SHA-256"), class: "form-control" %>
+    </div>
   </div>
   <div class="col-md-9">
-	<div class="form-group">
-	<%= label_tag "content_checksum", "Checksum" %>
-	<%= text_field_tag "content[checksum]", nil, class: "form-control" %>
-	<span class="help-block">Optional checksum to validate against the repository</span>
-	</div>
+    <div class="form-group">
+      <%= label_tag "content_checksum", "Checksum" %>
+      <%= text_field_tag "content[checksum]", nil, class: "form-control" %>
+      <span class="help-block">Optional checksum to validate against the repository</span>
+    </div>
   </div>
 </div>
 

--- a/app/views/application/upload.html.erb
+++ b/app/views/application/upload.html.erb
@@ -7,8 +7,8 @@
 
   <% if current_object.has_content? %>
     <p class="alert alert-warning">
-	  <strong>Warning!</strong> <%= t('dul_hydra.upload.alerts.has_content') %>
-	</p>
+      <strong>Warning!</strong> <%= t('dul_hydra.upload.alerts.has_content') %>
+    </p>
   <% end %>
 
   <%= render 'select_content_file' %>
@@ -16,7 +16,7 @@
   <%= render 'form_comment' %>
 
   <div class="well well-sm form-group">
-	<%= cancel_button class: "pull-right" %>
-	<%= submit_tag "Upload", class: "btn btn-primary" %>
+    <%= cancel_button class: "pull-right" %>
+    <%= submit_tag "Upload", class: "btn btn-primary" %>
   </div>
 <% end %>


### PR DESCRIPTION
This does implement the suggested solution of putting a "required"
attribute on the file form field because the code currently uses
a partial that is shared with the Item new template, where the file
is only conditionally required (to create a new Component when
the Item is created).
Closes #1145