### PR TITLE
Reconfigures index-related tasks

### DIFF
--- a/lib/dul_hydra/jobs/update_index.rb
+++ b/lib/dul_hydra/jobs/update_index.rb
@@ -1,0 +1,12 @@
+module DulHydra::Jobs
+  class UpdateIndex
+
+    @queue = :index
+
+    def self.perform(pid)
+      obj = ActiveFedora::Base.find(pid)
+      obj.update_index
+    end
+
+  end
+end


### PR DESCRIPTION
Index-related tasks moved from dul_hydra:solr to dul_hydra:index
namespace.
dul_hydra:index:update_all uses DulHydra::Jobs::UpdateIndex job
to permit multi-worker processing.