### PR TITLE
Adds Versions tab to content-bearing objects.

### DIFF
--- a/app/controllers/concerns/dul_hydra/controller/has_content_behavior.rb
+++ b/app/controllers/concerns/dul_hydra/controller/has_content_behavior.rb
@@ -6,6 +6,7 @@ module DulHydra
       included do
         before_action :upload_content, only: :create
         self.tabs.unshift :tab_tech_metadata
+        self.tabs << :tab_versions
         helper_method :tech_metadata_fields
       end
 
@@ -23,6 +24,16 @@ module DulHydra
               redirect_to(action: "show") and return
             end
           end
+        end
+      end
+
+      def versions
+        if request.xhr?
+          # For async loading of tab content
+          @tab = tab_versions
+          render "versions", layout: false
+        else
+          redirect_to action: "show", tab: "versions"
         end
       end
 
@@ -72,6 +83,19 @@ module DulHydra
                                 show_ds_download_link?(current_object.fits)
                                ),
                 ]
+               )
+      end
+
+      def tab_versions
+        Tab.new("versions",
+                actions: [
+                  TabAction.new("upload",
+                                url_for(id: current_object, action: "upload"),
+                                can?(:upload, current_object)
+                               ),
+                ],
+                guard: current_object.has_content?,
+                href: url_for(id: current_object, action: "versions")
                )
       end
 

--- a/app/views/application/_object_info.html.erb
+++ b/app/views/application/_object_info.html.erb
@@ -32,13 +32,6 @@
   <% else %>
     <%= object_info_item label: "virus.not_scanned", status: "warning" %>
   <% end %>
-
-  <% if current_object.has_content? %>
-  <li class="list-group-item">
-    <span class="badge"><%= current_object.content.versions.length %></span>
-    <%= t("dul_hydra.object_info.versions") %>
-  </li>
-  <% end %>
 <% end %>
 
 <%# EVENTS %>

--- a/app/views/application/_versions.html.erb
+++ b/app/views/application/_versions.html.erb
@@ -1,0 +1,22 @@
+<%= render partial: 'tab_actions', locals: {tab: tab} %>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">Version</th>
+      <th scope="col">Date</th>
+      <th scope="col">Media Type</th>
+      <th scope="col">Size</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% current_object.content.versions.each do |version| %>
+    <tr>
+      <td><%= version.dsVersionID %></td>
+      <td><%= version.dsCreateDate %></td>
+      <td><%= version.mimeType %></td>
+      <td><%= version.dsSize %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/application/versions.html.erb
+++ b/app/views/application/versions.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'versions', locals: {tab: @tab} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,14 +151,13 @@ en:
         label: Roles
         actions:
           edit: Modify
+      versions:
+        actions:
+          upload: "Upload New Version"
       admin_metadata:
         label: Admin Metadata
         actions:
           edit: Edit
-      collection_info:
-        label: "Collection Info"
-        actions:
-          download: "Download CSV Report"
       pending_batches:
           label: Pending
       finished_batches:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,10 +16,6 @@ DulHydra::Application.routes.draw do
     /[a-zA-Z0-9\-_]+:[a-zA-Z0-9\-_]+/
   end
 
-  def tab_constraint
-    /attachments|items|components|descriptive_metadata|permissions|default_permissions/
-  end
-
   namespace :admin do
     get 'dashboard', to: 'dashboard#show'
     get 'reports/:type', to: 'reports#show', as: 'report', constraints: {format: 'csv'}
@@ -34,6 +30,7 @@ DulHydra::Application.routes.draw do
   def content_routes
     get 'upload'
     patch 'upload'
+    get 'versions'
   end
 
   def event_routes

--- a/lib/dul_hydra/ability_definitions/alias_ability_definitions.rb
+++ b/lib/dul_hydra/ability_definitions/alias_ability_definitions.rb
@@ -2,7 +2,8 @@ module DulHydra
   class AliasAbilityDefinitions < Ddr::Auth::AbilityDefinitions
 
     def call
-      alias_action :attachments, :collection_info, :components, :event, :events, :items, :targets, to: :read
+      alias_action :attachments, :components, :event, :events, :items, :targets, :versions,
+                   to: :read
       alias_action :roles, to: :grant
       alias_action :admin_metadata, to: :update
       alias_action :report, to: :audit

--- a/spec/lib/dul_hydra/ability_definitions/alias_ability_definitions_spec.rb
+++ b/spec/lib/dul_hydra/ability_definitions/alias_ability_definitions_spec.rb
@@ -10,7 +10,7 @@ module DulHydra
 
     it "should alias actions to :read" do
       expect(subject.aliased_actions[:read])
-        .to include(:attachments, :collection_info, :components, :event, :events, :items, :targets)
+        .to include(:attachments, :components, :event, :events, :items, :targets, :versions)
     end
     it "should alias actions to :grant" do
       expect(subject.aliased_actions[:grant]).to include(:roles)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -10,7 +10,7 @@ describe Ability, type: :model, abilities: true do
   describe "aliases" do
     it "should alias actions to :read" do
       expect(subject.aliased_actions[:read])
-        .to include(:attachments, :collection_info, :components, :event, :events, :items, :targets)
+        .to include(:attachments, :components, :event, :events, :items, :targets, :versions)
     end
     it "should alias actions to :grant" do
       expect(subject.aliased_actions[:grant]).to include(:roles)


### PR DESCRIPTION
Closes #1392
Tab content loads asynchronously.
Versions removed from object info sidebar.