### PR TITLE
Display original file name on Admin Metdata tab; closes #1456.

### DIFF
--- a/app/controllers/concerns/dul_hydra/controller/has_content_behavior.rb
+++ b/app/controllers/concerns/dul_hydra/controller/has_content_behavior.rb
@@ -39,6 +39,10 @@ module DulHydra
 
       protected
 
+      def admin_metadata_fields
+        super + [ :original_filename ]
+      end
+
       def tech_metadata_fields
         DulHydra.techmd_show_fields.map do |field|
           [field, Array(current_object.techmd.send(field))]

--- a/app/views/admin_metadata_form/_original_filename.html.erb
+++ b/app/views/admin_metadata_form/_original_filename.html.erb
@@ -1,0 +1,4 @@
+<%= f.label :original_filename %>
+<p class="form-control-static">
+  <%= f.text_field :original_filename, disabled: true %>
+</p>


### PR DESCRIPTION
Appears on Admin Metadata tab only for content-bearing objects.
Original file name not editable on Modify form.