### PR TITLE
Fix 'get_children' method to work with new code versions; closes #1529.

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -9,11 +9,7 @@ class CollectionsController < ApplicationController
   self.tabs += [ :tab_reports, :tab_actions ]
 
   def items
-    #get_children
-    configure_blacklight_for_children
-    rel = { Collection.reflect_on_association(:children) => current_object.id }
-    query = ActiveFedora::SolrQueryBuilder.construct_query_for_rel(rel)
-    @response, @document_list = get_search_results(params, {q: query})
+    get_children
   end
 
   def report

--- a/app/controllers/concerns/dul_hydra/controller/has_children_behavior.rb
+++ b/app/controllers/concerns/dul_hydra/controller/has_children_behavior.rb
@@ -7,7 +7,8 @@ module DulHydra
       def get_children
         configure_blacklight_for_children
         # Set instance vars for compatibility with Blacklight helpers and views
-        query = current_object.association_query(:children)
+        rel = { current_object.class.reflect_on_association(:children) => current_object.id }
+        query = ActiveFedora::SolrQueryBuilder.construct_query_for_rel(rel)
         @response, @document_list = get_search_results(params, {q: query})
       end
 


### PR DESCRIPTION
Refactors previous fix made in CollectionsController so that it can also be used in ItemsController.