### PR TITLE
Verify AF::File checksums after object migration; closes #1553.

### DIFF
--- a/lib/dul_hydra/migration.rb
+++ b/lib/dul_hydra/migration.rb
@@ -13,5 +13,6 @@ module DulHydra
     autoload :MigrateSingleObjectJob
     autoload :MigrateSingleObjectRelationshipsJob
     autoload :SourceObjectIntegrity
+    autoload :TargetObjectIntegrity
   end
 end

--- a/lib/dul_hydra/migration/target_object_integrity.rb
+++ b/lib/dul_hydra/migration/target_object_integrity.rb
@@ -1,0 +1,51 @@
+# require 'equivalent-xml'
+
+module DulHydra::Migration
+  class TargetObjectIntegrity
+
+    attr_reader :source, :target
+
+    def initialize(source, target)
+      @source = source
+      @target = target
+    end
+
+    def verify
+      source.datastreams.each do |dsid, datastream|
+        if [ 'content', 'thumbnail', 'fits', 'extractedText' ].include?(dsid)
+          verify_existence(dsid)
+          if dsid == 'fits'
+            verify_equivalence(dsid, datastream)
+          else
+            verify_checksum(dsid, datastream)
+          end
+        end
+      end
+    end
+
+    private
+
+    def verify_existence(dsid)
+      unless target.attached_files[dsid]
+        raise FedoraMigrate::Errors::MigrationError, "Failed to migrate #{source.pid} #{dsid}"
+      end
+    end
+
+    def verify_checksum(dsid, datastream)
+      target_checksum = target.attached_files[dsid].checksum
+      unless target_checksum.value == datastream.checksum
+        raise FedoraMigrate::Errors::MigrationError,
+              "Checksum mismatch: #{dsid} #{source.pid} #{datastream.checksumType} #{datastream.checksum} #{target.id} #{target_checksum.algorithm} #{target_checksum.value}"
+      end
+    end
+
+    def verify_equivalence(dsid, datastream)
+      source_xml_doc = Nokogiri::XML(datastream.content)
+      target_xml_doc = Nokogiri::XML(target.attached_files[dsid].content)
+      unless EquivalentXml.equivalent?(target_xml_doc, source_xml_doc)
+        raise FedoraMigrate::Errors::MigrationError, "Equivalence mismatch: fits #{source.pid} #{target.id}"
+      end
+    end
+
+  end
+end

--- a/lib/tasks/fedora-migrate.rake
+++ b/lib/tasks/fedora-migrate.rake
@@ -12,6 +12,7 @@ module FedoraMigrate::Hooks
 
   def after_object_migration
     DulHydra::Migration::OriginalFilename.new(self).migrate if target.can_have_content?
+    DulHydra::Migration::TargetObjectIntegrity.new(self.source, self.target).verify
   end
 
   def before_rdf_datastream_migration

--- a/spec/migration/source_object_integrity_spec.rb
+++ b/spec/migration/source_object_integrity_spec.rb
@@ -2,6 +2,9 @@ require 'migration_helper'
 
 module DulHydra::Migration
   RSpec.describe SourceObjectIntegrity do
+
+    subject { described_class.new(source) }
+
     let(:source) { Rubydora::DigitalObject.new('test:1') }
     let(:datastream) { Rubydora::Datastream.new(source, 'content') }
 
@@ -14,7 +17,7 @@ module DulHydra::Migration
         allow(datastream).to receive(:dsChecksumValid) { false }
       end
       it "should raise an exception" do
-        expect { described_class.new(source).verify }.to raise_error(FedoraMigrate::Errors::MigrationError)
+        expect { subject.verify }.to raise_error(FedoraMigrate::Errors::MigrationError)
       end
     end
 
@@ -22,8 +25,8 @@ module DulHydra::Migration
       before do
         allow(datastream).to receive(:dsChecksumValid) { true }
       end
-      it "should raise an exception" do
-        expect { described_class.new(source).verify }.not_to raise_error
+      it "should not raise an exception" do
+        expect { subject.verify }.not_to raise_error
       end
     end
 

--- a/spec/migration/target_object_integrity_spec.rb
+++ b/spec/migration/target_object_integrity_spec.rb
@@ -1,0 +1,79 @@
+require 'migration_helper'
+
+module DulHydra::Migration
+  RSpec.describe TargetObjectIntegrity do
+
+    subject { described_class.new(source, target) }
+
+    let(:source) { Rubydora::DigitalObject.new('test:1') }
+    let(:target) { Component.new }
+    let(:target_file) { ActiveFedora::File.new }
+
+    context "datastream not migrated" do
+      let(:source_datastream) { Rubydora::Datastream.new(source, 'content') }
+      before do
+        allow(source).to receive(:datastreams) { [ [ 'content', source_datastream ] ] }
+        allow(target).to receive(:attached_files) { { } }
+      end
+      it "should raise an exception" do
+        expect { subject.verify }.to raise_error(FedoraMigrate::Errors::MigrationError)
+      end
+    end
+
+    context "datastream migrated" do
+
+      context "OM datastream" do
+        let(:source_datastream) { Rubydora::Datastream.new(source, 'fits') }
+        before do
+          allow(source).to receive(:datastreams) { [ [ 'fits', source_datastream ] ] }
+          allow(source_datastream).to receive(:content) { '<fits />' }
+          allow(target).to receive(:attached_files) { { 'fits' => target_file } }
+        end
+        describe "when equivalence verification fails on a datastream" do
+          before do
+            allow(target_file).to receive(:content) { "<?xml version=\"1.0\"?><fats />" }
+          end
+          it "should raise an exception" do
+            expect { subject.verify }.to raise_error(FedoraMigrate::Errors::MigrationError)
+          end
+        end
+        describe "when equivalence verification does not fail on any datastream" do
+          before do
+            allow(target_file).to receive(:content) { "<?xml version=\"1.0\"?><fits />" }
+          end
+          it "should not raise an exception" do
+            expect { subject.verify }.not_to raise_error
+          end
+        end
+      end
+
+      context "not OM datastream" do
+        let(:source_datastream) { Rubydora::Datastream.new(source, 'content') }
+        before do
+          allow(source).to receive(:datastreams) { [ [ 'content', source_datastream ] ] }
+          allow(source_datastream).to receive(:checksum) { '75e2e0cec6e807f6ae63610d46448f777591dd6b' }
+          allow(source_datastream).to receive(:checksumType) { 'SHA-1' }
+          allow(target).to receive(:attached_files) { { 'content' => target_file } }
+        end
+        describe "when checksum verification fails on a datastream" do
+          before do
+            allow(target_file).to receive(:digest) { [ RDF::URI.new('urn:sha1:2cf23f0035c12b6242093e93d0f7eeba0b1e08e8') ] }
+          end
+          it "should raise an exception" do
+            expect { subject.verify }.to raise_error(FedoraMigrate::Errors::MigrationError)
+          end
+        end
+        describe "when checksum verification does not fail on any datastream" do
+          before do
+            allow(target_file).to receive(:digest) { [ RDF::URI.new('urn:sha1:75e2e0cec6e807f6ae63610d46448f777591dd6b') ] }
+          end
+          it "should not raise an exception" do
+            expect { subject.verify }.not_to raise_error
+          end
+        end
+      end
+
+    end
+
+  end
+end

--- a/test/integration/migration/tests/migration_spec.rb
+++ b/test/integration/migration/tests/migration_spec.rb
@@ -5,7 +5,7 @@ require 'dul_hydra/migration'
 
 RSpec.describe 'migration' do
 
-  let(:f3_jetty_zip_fixture) { 'f3-migration-jetty-C.zip' }
+  let(:f3_jetty_zip_fixture) { 'f3-migration-jetty-D.zip' }
   let(:f3_jetty_zip_fixture_path) { Rails.root.join('test', 'integration', 'migration', 'fixtures', f3_jetty_zip_fixture) }
   let(:f3_temp_dir) { Dir.mktmpdir }
   let(:f3_jetty_dir) { File.join(f3_temp_dir, 'jetty') }
@@ -20,6 +20,7 @@ RSpec.describe 'migration' do
       end
       def after_object_migration
         DulHydra::Migration::OriginalFilename.new(self).migrate if target.can_have_content?
+        DulHydra::Migration::TargetObjectIntegrity.new(self.source, self.target).verify
       end
       def before_rdf_datastream_migration
         if source.dsid == "mergedMetadata"
@@ -68,7 +69,7 @@ RSpec.describe 'migration' do
     expect(subj.roles.granted?(agent: 'repo:metadata_editors', role_type: 'MetadataEditor', scope: 'policy')).to be true
     expect(subj.admin_policy).to eq(duke_1)
     expect(subj.thumbnail.mime_type).to eq('image/png')
-    expect(subj.thumbnail.size).to eq(25037)
+    expect(subj.thumbnail.checksum.value).to eq('200e3f3a78e0230292245dbd29193182298cd469')
     # duke:2
     subj = duke_2
     expect(subj).to be_a(Item)
@@ -80,22 +81,22 @@ RSpec.describe 'migration' do
     expect(subj.structMetadata.mime_type).to eq('text/xml')
     expect(subj.structMetadata.content.length).to eq(379)
     expect(subj.thumbnail.mime_type).to eq('image/png')
-    expect(subj.thumbnail.size).to eq(25037)
+    expect(subj.thumbnail.checksum.value).to eq('200e3f3a78e0230292245dbd29193182298cd469')
     # duke:3
     subj = duke_3
     expect(subj).to be_a(Component)
     expect(subj.permanent_id).to eq('ark:/99999/fk4fx7hc5z')
     expect(subj.desc_metadata.title).to be_empty
-    expect(subj.multires_image_file_path).to eq('/tmp/image-server-data/0/b/4f/0b4fc12b-ce86-46e2-be6b-6ac8e2cfba6b/dscsi010010010.ptif')
+    expect(subj.multires_image_file_path).to eq('/tmp/image-server-data/9/3/ec/93ecb451-d63e-46a4-8d13-2c596d2f73ef/dscsi010010010.ptif')
     expect(subj.roles.count).to eq(0)
     expect(subj.legacy_original_filename).to be_nil
     expect(subj.admin_policy).to eq(duke_1)
     expect(subj.parent).to eq(duke_2)
     expect(subj.content.mime_type).to eq('image/tiff')
     expect(subj.content.original_name).to eq('dscsi010010010.tif')
-    expect(subj.content.size).to eq(4481808)
+    expect(subj.content.checksum.value).to eq('67db06ad416d7a12b0a7e193fbe3cc971478bfd9')
     expect(subj.thumbnail.mime_type).to eq('image/png')
-    expect(subj.thumbnail.size).to eq(25037)
+    expect(subj.thumbnail.checksum.value).to eq('200e3f3a78e0230292245dbd29193182298cd469')
     expect(subj.fits.mime_type).to eq('text/xml')
     expect(subj.fits.content.length).to eq(4566)
     # duke:5
@@ -103,16 +104,16 @@ RSpec.describe 'migration' do
     expect(subj).to be_a(Component)
     expect(subj.permanent_id).to eq('ark:/99999/fk4b56sk1k')
     expect(subj.desc_metadata.title).to be_empty
-    expect(subj.multires_image_file_path).to eq('/tmp/image-server-data/e/3/84/e3847b68-ebfa-4b28-837a-1401789947f8/dscsi010010020.ptif')
+    expect(subj.multires_image_file_path).to eq('/tmp/image-server-data/e/2/22/e222c06d-eee1-4c28-9368-deb4022fd87b/dscsi010010020.ptif')
     expect(subj.roles.count).to eq(0)
     expect(subj.legacy_original_filename).to be_nil
     expect(subj.admin_policy).to eq(duke_1)
     expect(subj.parent).to eq(duke_2)
     expect(subj.content.mime_type).to eq('image/tiff')
     expect(subj.content.original_name).to eq('dscsi010010020.tif')
-    expect(subj.content.size).to eq(4688604)
+    expect(subj.content.checksum.value).to eq('e6ca91f2de4caa2a7246aaa323268d8357514760')
     expect(subj.thumbnail.mime_type).to eq('image/png')
-    expect(subj.thumbnail.size).to eq(14721)
+    expect(subj.thumbnail.checksum.value).to eq('ebe2258ef66be055cb1a0da9be08577bd65c29b6')
     expect(subj.fits.mime_type).to eq('text/xml')
     expect(subj.fits.content.length).to eq(4558)
     # duke:6
@@ -126,7 +127,7 @@ RSpec.describe 'migration' do
     expect(subj.collection).to eq(duke_1)
     expect(subj.content.mime_type).to eq('image/tiff')
     expect(subj.content.original_name).to eq('dscT001.tif')
-    expect(subj.content.size).to eq(28507714)
+    expect(subj.content.checksum.value).to eq('9443a4dbcf2091af929ba07b4651e6991760a7d6')
     expect(subj.fits.mime_type).to eq('text/xml')
     expect(subj.fits.content.length).to eq(5817)
     # duke:7
@@ -168,7 +169,7 @@ RSpec.describe 'migration' do
     expect(subj.parent).to eq(duke_8)
     expect(subj.content.mime_type).to eq('text/comma-separated-values')
     expect(subj.content.original_name).to eq('product-list_300.csv')
-    expect(subj.content.size).to eq(493)
+    expect(subj.content.checksum.value).to eq('3aeafead5f4130932233315067d7b16c65e415f4')
     expect(subj.fits.mime_type).to eq('text/xml')
     expect(subj.fits.content.length).to eq(2409)
     # duke:11
@@ -184,7 +185,7 @@ RSpec.describe 'migration' do
     expect(subj.parent).to eq(duke_9)
     expect(subj.content.mime_type).to eq('application/pdf')
     expect(subj.content.original_name).to eq('J20110711-00608.pdf')
-    expect(subj.content.size).to eq(203237)
+    expect(subj.content.checksum.value).to eq('b4a33e872beb5ceb2a9e3c1b192c983f5500c8b9')
     expect(subj.fits.mime_type).to eq('text/xml')
     expect(subj.fits.content.length).to eq(3785)
   end


### PR DESCRIPTION
Also updates migration integration test to use f3-migration-jetty-D.zip,
which uses SHA-1 checksums in the Fedora 3 source repository.