### PR TITLE
No longer prepends "info:fedora/" to id in fptr

### DIFF
--- a/app/services/build_batch_object_from_mets_file.rb
+++ b/app/services/build_batch_object_from_mets_file.rb
@@ -158,7 +158,7 @@ class BuildBatchObjectFromMETSFile
 
   def create_fptr(stru, div, pid)
     fptr = Nokogiri::XML::Node.new('fptr', stru.as_xml_document)
-    fptr['CONTENTIDS'] = "info:fedora/#{pid}"
+    fptr['CONTENTIDS'] = pid
     div.add_child(fptr)
   end
 

--- a/spec/services/build_batch_object_from_mets_file_spec.rb
+++ b/spec/services/build_batch_object_from_mets_file_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe BuildBatchObjectFromMETSFile, type: :service, batch: true, mets_f
 
   before do
     allow(File).to receive(:read).with(mets_filepath) { sample_mets_xml }
-    allow(Ddr::Utils).to receive(:pid_for_identifier).with('efghi01003', collection: collection) { 'test:7' }
-    allow(Ddr::Utils).to receive(:pid_for_identifier).with('efghi010030010', model: 'Component') { 'test:19' }
-    allow(Ddr::Utils).to receive(:pid_for_identifier).with('efghi010030020', model: 'Component') { 'test:20' }
+    allow(Ddr::Utils).to receive(:pid_for_identifier).with('efghi01003', collection: collection) { 'test-7' }
+    allow(Ddr::Utils).to receive(:pid_for_identifier).with('efghi010030010', model: 'Component') { 'test-19' }
+    allow(Ddr::Utils).to receive(:pid_for_identifier).with('efghi010030020', model: 'Component') { 'test-20' }
   end
 
   context "batch object" do

--- a/spec/support/metadata_helper.rb
+++ b/spec/support/metadata_helper.rb
@@ -95,10 +95,10 @@ def sample_xml_struct_metadata
     <mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
       <structMap TYPE="default">
         <div LABEL="1" TYPE="Image" ID="efghi010030010" ORDER="1">
-          <fptr CONTENTIDS="info:fedora/test:19"/>
+          <fptr CONTENTIDS="test-19"/>
         </div>
         <div LABEL="2" TYPE="Image" ID="efghi010030020" ORDER="2">
-          <fptr CONTENTIDS="info:fedora/test:20"/>
+          <fptr CONTENTIDS="test-20"/>
         </div>
       </structMap>
     </mets>


### PR DESCRIPTION
Fixes #1571