### PR TITLE
Remove 'duke:migrate:all' task.

### DIFF
--- a/lib/tasks/fedora-migrate.rake
+++ b/lib/tasks/fedora-migrate.rake
@@ -28,12 +28,6 @@ end
 
 namespace :duke do
   namespace :migrate do
-    desc "Migrate all my objects"
-    task all: :environment do
-      FedoraMigrate.migrate_repository(namespace: "duke",
-                                       options: { convert: [ 'mergedMetadata' ] })
-      DulHydra::Migration::MigrateStructMetadata.migrate
-    end
     desc "Empty out the Fedora4 repository and migration reports"
     task reset: :environment do
       ActiveFedora::Cleaner.clean!


### PR DESCRIPTION
Not needed since we have no plans to migrate entire repository as a single task.