### PR TITLE
Batch 'process' action redirects to 'show' view; closes #1583.

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -36,7 +36,7 @@ class BatchesController < ApplicationController
   def procezz
     Resque.enqueue(Ddr::Batch::BatchProcessorJob, @batch.id, current_user.id)
     flash[:notice] = I18n.t('batch.web.batch_queued', :id => @batch.id)
-    redirect_to batches_url
+    redirect_to batch_url
   end
 
   def validate

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -77,10 +77,10 @@ describe BatchesController, type: :controller, batch: true do
       expect(Resque).to receive(:enqueue).with(Ddr::Batch::BatchProcessorJob, batch.id, batch.user.id)
       get :procezz, :id => batch.id
     end
-    it "should redirect to the batches url" do
+    it "should redirect to the batch url" do
       allow(Resque).to receive(:enqueue).with(Ddr::Batch::BatchProcessorJob, batch.id, batch.user.id)
       get :procezz, :id => batch.id
-      expect(response).to redirect_to(batches_url)
+      expect(response).to redirect_to(batch_url)
     end
   end
 


### PR DESCRIPTION
Instead of 'index' view.