### PR TITLE
Add METSFolder ability definitions; closes # 1623.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,6 +5,7 @@ class Ability < Ddr::Auth::Ability
                                 DulHydra::ExportSetAbilityDefinitions,
                                 DulHydra::MetadataFileAbilityDefinitions,
                                 DulHydra::IngestFolderAbilityDefinitions,
+                                DulHydra::METSFolderAbilityDefinitions,
                               ]
 
 end

--- a/app/views/collections/_actions.html.erb
+++ b/app/views/collections/_actions.html.erb
@@ -14,7 +14,7 @@
 	%>
   </li>
   <li class="list-group-item">
-    <%= link_to_if can?(:edit, current_object),
+    <%= link_to_if can?(:create, METSFolder.new(collection_id: current_object.id)),
         'METS Folder Update',
         new_mets_folder_path(mets_folder: { collection_id: current_object })
     %>

--- a/lib/dul_hydra.rb
+++ b/lib/dul_hydra.rb
@@ -12,6 +12,7 @@ module DulHydra
     autoload :BatchAbilityDefinitions
     autoload :MetadataFileAbilityDefinitions
     autoload :IngestFolderAbilityDefinitions
+    autoload :METSFolderAbilityDefinitions
   end
 
   include DulHydra::Configurable

--- a/lib/dul_hydra/ability_definitions/mets_folder_ability_definitions.rb
+++ b/lib/dul_hydra/ability_definitions/mets_folder_ability_definitions.rb
@@ -1,0 +1,12 @@
+module DulHydra
+  class METSFolderAbilityDefinitions < Ddr::Auth::AbilityDefinitions
+
+    def call
+      can :create, METSFolder do |mf|
+        can? :edit, Collection.find(mf.collection_id)
+      end
+      can [:show, :procezz], METSFolder, user: user
+    end
+
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -89,4 +89,47 @@ describe Ability, type: :model, abilities: true do
     end
   end
 
+  describe "METSFolder abilities" do
+    describe "create" do
+      let(:collection) { Collection.new(id: 'ab/cd/ef/abcdefgh') }
+      let(:resource) { METSFolder.new(collection_id: collection.id) }
+      before do
+        allow(subject).to receive(:can?).and_call_original
+        allow(Collection).to receive(:find) { collection }
+      end
+      describe "when the user can edit the collection" do
+        before { allow(subject).to receive(:can?).with(:edit, collection) { true } }
+        it { should be_able_to(:create, resource) }
+      end
+      describe "when the user cannot edit the collection" do
+        before { allow(subject).to receive(:can?).with(:edit, collection) { false } }
+        it { should_not be_able_to(:create, resource) }
+      end
+    end
+
+    describe "show" do
+      let(:user) { FactoryGirl.build(:user) }
+      let(:resource) { METSFolder.new(user: user) }
+      describe "when the user is the creator of the METSFolder" do
+        before { allow(auth_context).to receive(:user) { resource.user } }
+        it { should be_able_to(:show, resource) }
+      end
+      describe "when the user is not the creator of the METSFolder" do
+        it { should_not be_able_to(:show, resource) }
+      end
+    end
+
+    describe "procezz" do
+      let(:user) { FactoryGirl.build(:user) }
+      let(:resource) { METSFolder.new(user: user) }
+      describe "when the user is the creator of the METSFolder" do
+        before { allow(auth_context).to receive(:user) { resource.user } }
+        it { should be_able_to(:procezz, resource) }
+      end
+      describe "when the user is not the creator of the METSFolder" do
+        it { should_not be_able_to(:procezz, resource) }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Can create METSFolder if can edit collection associated with METSFolder.
Can show, procezz METSFolder if user who created the METSFolder.