### PR TITLE
Do not update local_id; closes #1627

### DIFF
--- a/app/services/build_batch_object_from_mets_file.rb
+++ b/app/services/build_batch_object_from_mets_file.rb
@@ -16,7 +16,6 @@ class BuildBatchObjectFromMETSFile
 
   def create_update_object
     update_object = Ddr::Batch::UpdateBatchObject.create(batch: batch, pid: mets_file.repo_pid, identifier: mets_file.local_id)
-    add_local_id(update_object) if mets_file.local_id.present?
     if display_format = METSFileDisplayFormat.get(mets_file, display_formats)
       add_display_format(update_object, display_format)
     end
@@ -26,21 +25,6 @@ class BuildBatchObjectFromMETSFile
     add_aspace_id(update_object) if mets_file.aspace_id.present?
     add_struct_metadata(update_object) if mets_file.struct_metadata.present?
     update_object
-  end
-
-  def add_local_id(update_object)
-    Ddr::Batch::BatchObjectAttribute.create(
-      batch_object: update_object,
-      datastream: Ddr::Models::Metadata::ADMIN_METADATA,
-      name: 'local_id',
-      operation: Ddr::Batch::BatchObjectAttribute::OPERATION_CLEAR)
-    Ddr::Batch::BatchObjectAttribute.create(
-      batch_object: update_object,
-      datastream: Ddr::Models::Metadata::ADMIN_METADATA,
-      name: 'local_id',
-      value: mets_file.local_id,
-      value_type: Ddr::Batch::BatchObjectAttribute::VALUE_TYPE_STRING,
-      operation: Ddr::Batch::BatchObjectAttribute::OPERATION_ADD)
   end
 
   def add_display_format(update_object, display_format)

--- a/spec/services/build_batch_object_from_mets_file_spec.rb
+++ b/spec/services/build_batch_object_from_mets_file_spec.rb
@@ -25,19 +25,11 @@ RSpec.describe BuildBatchObjectFromMETSFile, type: :service, batch: true, mets_f
   end
 
   context "local id" do
-    it "should clear and re-assign the local id" do
+    it "should leave the local id alone" do
       batch_object = service.call
       attrs = batch_object.batch_object_attributes
-      clear_attrs = attrs.where(datastream: Ddr::Models::Metadata::ADMIN_METADATA,
-                                operation: Ddr::Batch::BatchObjectAttribute::OPERATION_CLEAR,
-                                name: 'local_id')
-      add_attrs = attrs.where(datastream: Ddr::Models::Metadata::ADMIN_METADATA,
-                              operation: Ddr::Batch::BatchObjectAttribute::OPERATION_ADD,
-                              name: 'local_id',
-                              value: 'efghi01003')
-      expect(clear_attrs.size).to eq(1)
-      expect(add_attrs.size).to eq(1)
-      expect(clear_attrs.first.id).to be < add_attrs.first.id
+      local_id_attrs = attrs.where(name: 'local_id')
+      expect(local_id_attrs.size).to eq(0)
     end
   end
 


### PR DESCRIPTION
Updating the local_id while processing METS files is unnecessary.