### PR TITLE
Display Fedora 3 PID on Admin Metadata tab; closes #1654.

### DIFF
--- a/app/controllers/concerns/dul_hydra/controller/repository_behavior.rb
+++ b/app/controllers/concerns/dul_hydra/controller/repository_behavior.rb
@@ -133,7 +133,7 @@ module DulHydra
 
       # Controls what fields are displayed on the admin metadata tab and edit form
       def admin_metadata_fields
-        [:license, :local_id, :display_format, :ead_id, :aspace_id]
+        [:license, :local_id, :display_format, :ead_id, :aspace_id, :fcrepo3_pid]
       end
 
       def admin_metadata_params

--- a/app/views/admin_metadata_form/_fcrepo3_pid.html.erb
+++ b/app/views/admin_metadata_form/_fcrepo3_pid.html.erb
@@ -1,0 +1,4 @@
+<%= f.label :fcrepo3_pid, "Fedora 3 PID" %>
+<p class="form-control-static">
+  <%= f.text_field :fcrepo3_pid, disabled: true, style: "width:100%" %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,9 +4,10 @@ en:
       multiple_object_matches: "%{criteria} retrieved multiple repository objects"
   dul_hydra:
     admin_metadata:
-      local_id: "Local ID"
-      ead_id: "EAD ID"
       aspace_id: "ArchivesSpace ID"
+      ead_id: "EAD ID"
+      fcrepo3_pid: "Fedora 3 PID"
+      local_id: "Local ID"
     techmd:
       file_human_size: "File Size"
       pronom_identifier: "PRONOM Identifier"


### PR DESCRIPTION
Fedora 3 PID is non-editable on Admin Metadata edit form.