### PR TITLE
Fixes RDF parsing error

### DIFF
--- a/lib/dul_hydra/migration/roles.rb
+++ b/lib/dul_hydra/migration/roles.rb
@@ -12,7 +12,7 @@ module DulHydra::Migration
     end
 
     def graph
-      RDF::Graph.new.from_ntriples(source.content)
+      RDF::Graph.new.from_ntriples(source.content.force_encoding(Encoding::UTF_8))
     end
 
     def grant_roles_on_target!

--- a/spec/fixtures/migration/f3_descMetadata.nt
+++ b/spec/fixtures/migration/f3_descMetadata.nt
@@ -1,0 +1,2 @@
+<info:fedora/duke:141764> <http://purl.org/dc/terms/description> "Between 1875 and the 1940s, cigarette companies often included collectible trading cards with their packages of cigarettes.\r\n\r\nCigarette card sets document popular culture from the turn of the century, often depicting the period's actresses, costumes, and sports, as well as offering fascinating insights into mainstream American humor and cultural norms." .
+<info:fedora/duke:141764> <http://purl.org/dc/terms/title> "W. Duke, Sons & Co. Advertising Materials, 1880-1910" .

--- a/spec/fixtures/migration/f4_mergedMetadata.nt
+++ b/spec/fixtures/migration/f4_mergedMetadata.nt
@@ -6,3 +6,5 @@
 <info:fedora/duke:141764> <http://repository.lib.duke.edu/vocab/asset/workflowState> "published" .
 <info:fedora/duke:141764> <http://repository.lib.duke.edu/vocab/contact/assistance> "rubenstein" .
 <info:fedora/duke:141764> <http://repository.lib.duke.edu/vocab/asset/eadId> "dukeandsons" .
+<info:fedora/duke:141764> <http://purl.org/dc/terms/description> "Between 1875 and the 1940s, cigarette companies often included collectible trading cards with their packages of cigarettes.\r\n\r\nCigarette card sets document popular culture from the turn of the century, often depicting the period's actresses, costumes, and sports, as well as offering fascinating insights into mainstream American humor and cultural norms." .
+<info:fedora/duke:141764> <http://purl.org/dc/terms/title> "W. Duke, Sons & Co. Advertising Materials, 1880-1910" .

--- a/spec/migration/roles_spec.rb
+++ b/spec/migration/roles_spec.rb
@@ -6,8 +6,10 @@ module DulHydra::Migration
     subject { described_class.new(mover) }
 
     let(:mover) { double(source: source, target: target) }
-    let(:f3_ntriples) { fixture_file_upload("migration/f3_adminMetadata.nt").read }
-    let(:f4_ntriples) { fixture_file_upload("migration/f4_adminMetadata.nt").read }
+    let(:f3_amd) { fixture_file_upload("migration/f3_adminMetadata.nt").read }
+    let(:f3_dmd) { fixture_file_upload("migration/f3_descMetadata.nt").read }
+    let(:f3_ntriples) { [ f3_amd, f3_dmd ].join("\n") }
+    let(:f4_ntriples) { fixture_file_upload("migration/f4_mergedMetadata.nt").read }
     let(:source) { ::Rubydora::Datastream.new(nil, nil, content: f3_ntriples) }
     let(:target) { Item.new }
 
@@ -16,7 +18,10 @@ module DulHydra::Migration
         expect { subject.migrate }.to change(source, :content).from(f3_ntriples).to(f4_ntriples)
       end
       it "adds the roles to target" do
+        puts f3_ntriples
+        puts source.content.encoding
         expect { subject.migrate }.to change { target.roles.as_json }.from({"roles"=>[]}).to({"roles"=>[{"agent"=>"repository_admins","role_type"=>"Curator","scope"=>"policy"},{"agent"=>"public","role_type"=>"Viewer","scope"=>"policy"},{"agent"=>"MetadataEditor1@duke.edu","role_type"=>"MetadataEditor","scope"=>"policy"},{"agent"=>"MetadataEditor2@duke.edu","role_type"=>"MetadataEditor","scope"=>"policy"},{"agent"=>"MetadataEditor3@duke.edu","role_type"=>"MetadataEditor","scope"=>"policy"},{"agent"=>"metadata_architects","role_type"=>"MetadataEditor","scope"=>"policy"}]})
+        puts source.content.encoding
       end
     end
 


### PR DESCRIPTION
The error occurs when there are embedded newlines in string literals
and the string encoding is ASCII_8BIT.  The Roles migrator neglected
to force the encoding to UTF-8 before attempting to load into an
RDF graph.