### PR TITLE
Completed batches display in descending order by start time; closes #…

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -6,7 +6,7 @@ class BatchesController < ApplicationController
   self.tabs = [:tab_pending_batches, :tab_finished_batches]
 
   def index
-    @batches = @batches.includes(:batch_objects, :user)
+    @batches = @batches.includes(:batch_objects, :user).order('start is not null, start DESC')
     @pending = []
     @finished = []
     @batches.each do |batch|

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -18,6 +18,18 @@ describe BatchesController, type: :controller, batch: true do
     end
   end
 
+  describe "#index" do
+    let(:user) { FactoryGirl.create(:user) }
+    let!(:batches) { [ Ddr::Batch::Batch.create(user: user, start: DateTime.now - 7),
+                       Ddr::Batch::Batch.create(user: user),
+                       Ddr::Batch::Batch.create(user: user, start: DateTime.now) ] }
+    before { sign_in user }
+    it "should display the batches in descending order by start time, with non-started batches first" do
+      get(:index)
+      expect(assigns(:batches)).to eq([ batches[1], batches[2], batches[0] ])
+    end
+  end
+
   describe "#destroy" do
     let(:batch) { FactoryGirl.create(:batch_with_basic_ingest_batch_objects) }
     before { sign_in batch.user }


### PR DESCRIPTION
…1644.

Unstarted batches appear first, followed by started batches in descending order (i.e., most
recently started first).