### PR TITLE
Require ActionView TextHelper; fixes #1731.

### DIFF
--- a/lib/dul_hydra/migration/migrate_single_object_struct_metadata_job.rb
+++ b/lib/dul_hydra/migration/migrate_single_object_struct_metadata_job.rb
@@ -1,6 +1,9 @@
+require 'action_view'
+
 module DulHydra::Migration
   class MigrateSingleObjectStructMetadataJob
     extend Ddr::Jobs::Job
+    extend ActionView::Helpers::TextHelper
 
     @queue = :migration
 
@@ -30,7 +33,7 @@ module DulHydra::Migration
     end
 
     def self.make_report(report, struct_metadata)
-      report.struct_metadata = truncate(struct_metadata.to_json, length: 65530)
+      report.struct_metadata = truncate(struct_metadata.to_json, length: 62000)
       report.struct_metadata_status = MigrationReport::MIGRATION_SUCCESS
       report.save!
     end

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "5.0.10"
+  VERSION = "5.0.11"
 end


### PR DESCRIPTION
Also truncate for migration_reports.struct_metadata at 62000 since previous value appears to be too high.