### PR TITLE
Hotfix 5.0.13

### DIFF
--- a/config/initializers/active_fedora_timeout_monkey_patch.rb
+++ b/config/initializers/active_fedora_timeout_monkey_patch.rb
@@ -1,0 +1,11 @@
+class ActiveFedora::Fedora
+  def authorized_connection
+    options = {}
+    if @config[:timeout]
+      options[:request] = { timeout: @config[:timeout].to_i }
+    end
+    connection = Faraday.new(host, options)
+    connection.basic_auth(user, password)
+    connection
+  end
+end

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "5.0.12"
+  VERSION = "5.0.13"
 end


### PR DESCRIPTION
Monkey-patches ActiveFedora::Fedora to inject :timeout from
Fedora config if present.