### PR TITLE
Adds capability to track job performance

### DIFF
--- a/app/jobs/abstract_job.rb
+++ b/app/jobs/abstract_job.rb
@@ -1,0 +1,17 @@
+require "resque"
+
+module AbstractJob
+
+  EVENT = "perform_job.dul_hydra".freeze
+
+  def around_perform_instrument(*args)
+    ActiveSupport::Notifications.instrument(EVENT,
+                                            args: args,
+                                            job: self.name,
+                                            queue: @queue.to_s
+                                           ) do
+      yield
+    end
+  end
+
+end

--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -1,5 +1,6 @@
 class FixityCheckJob
   extend Ddr::Jobs::Job
+  extend AbstractJob
 
   @queue = :fixity
 

--- a/app/models/job_performance.rb
+++ b/app/models/job_performance.rb
@@ -1,0 +1,34 @@
+class JobPerformance < ActiveRecord::Base
+
+  serialize :exception, JSON
+  serialize :args, JSON
+
+  class << self
+    attr_accessor :events
+
+    def enable!
+      ActiveSupport::Notifications.subscribe(events, self)
+    end
+
+    def disable!
+      ActiveSupport::Notifications.unsubscribe(self)
+    end
+
+    def call(*args)
+      event = ActiveSupport::Notifications::Event.new(*args)
+      job, queue = event.name.split(".")[0..1]
+      create(job: event.payload[:job],
+             args: event.payload[:args],
+             queue: event.payload[:queue],
+             started: event.time,
+             finished: event.end,
+             duration: event.duration,
+             exception: event.payload[:exception],
+             success: event.payload[:exception].nil?
+            )
+    end
+  end
+
+  self.events = AbstractJob::EVENT
+
+end

--- a/db/migrate/20160708165311_create_job_performance.rb
+++ b/db/migrate/20160708165311_create_job_performance.rb
@@ -1,0 +1,14 @@
+class CreateJobPerformance < ActiveRecord::Migration
+  def change
+    create_table :job_performances do |t|
+      t.string   :job, index: true
+      t.string   :queue, index: true
+      t.string   :args
+      t.datetime :started, index: true
+      t.datetime :finished, index: true
+      t.integer  :duration, index: true
+      t.string   :exception
+      t.boolean  :success, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160518153824) do
+ActiveRecord::Schema.define(version: 20160708165311) do
 
   create_table "batch_object_attributes", force: true do |t|
     t.integer  "batch_object_id"
@@ -148,6 +148,17 @@ ActiveRecord::Schema.define(version: 20160518153824) do
     t.integer  "parent_id_length"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "job_performances", force: true do |t|
+    t.string   "job"
+    t.string   "queue"
+    t.string   "args"
+    t.datetime "started"
+    t.datetime "finished"
+    t.integer  "duration"
+    t.string   "exception"
+    t.boolean  "success"
   end
 
   create_table "metadata_files", force: true do |t|

--- a/spec/models/job_performance_spec.rb
+++ b/spec/models/job_performance_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe JobPerformance, type: :model do
+
+  before(:all) {
+    class TestJob
+      extend AbstractJob
+      @queue = "test"
+
+      def self.perform(*args)
+        puts "Testing"
+      end
+    end
+  }
+
+  after(:all) {
+    Object.send(:remove_const, :TestJob)
+  }
+
+  describe ".enable!" do
+    specify {
+      expect(ActiveSupport::Notifications).to receive(:subscribe).with("perform_job.dul_hydra", described_class) { nil }
+      described_class.enable!
+    }
+  end
+
+  describe ".disable!" do
+    specify {
+      expect(ActiveSupport::Notifications).to receive(:unsubscribe).with(described_class) { nil }
+      described_class.disable!
+    }
+  end
+
+  describe "when subscribing to job events" do
+    around(:example) do |example|
+      callback = proc { |*args| described_class.call(*args) }
+      ActiveSupport::Notifications.subscribed(callback, "perform_job.dul_hydra") do
+        example.run
+      end
+    end
+
+    specify {
+      Resque.enqueue(TestJob, "foo")
+      job_perf = described_class.where(job: "TestJob").first
+      expect(job_perf.queue).to eq("test")
+      expect(job_perf.job).to eq("TestJob")
+      expect(job_perf.args).to eq(["foo"])
+      expect(job_perf.started).not_to be_nil
+      expect(job_perf.finished).not_to be_nil
+      expect(job_perf.duration).not_to be_nil
+      expect(job_perf.exception).to be_nil
+      expect(job_perf.success).to be true
+    }
+  end
+end


### PR DESCRIPTION
Closes #1745

Upgrade notes:
- rake db:migrate
- JobPerformance.enable! must be called explicity to enable tracking
- Jobs to be tracked must extend AbstractJob