### PR TITLE
Increase size of struct_metadata column in migration_reports database…

### DIFF
--- a/db/migrate/20160719131601_increase_migration_reports_column_size.rb
+++ b/db/migrate/20160719131601_increase_migration_reports_column_size.rb
@@ -1,0 +1,9 @@
+class IncreaseMigrationReportsColumnSize < ActiveRecord::Migration
+  def up
+    change_column :migration_reports, :struct_metadata, :text, limit: 16777215
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160126203842) do
+ActiveRecord::Schema.define(version: 20160719131601) do
 
   create_table "batch_object_attributes", force: true do |t|
     t.integer  "batch_object_id"
@@ -175,12 +175,12 @@ ActiveRecord::Schema.define(version: 20160126203842) do
     t.string   "fcrepo3_pid"
     t.string   "fcrepo4_id"
     t.string   "model"
-    t.string   "object_status",                        default: "NEEDED"
-    t.string   "relationship_status",                  default: "NEEDED"
+    t.string   "object_status",                           default: "NEEDED"
+    t.string   "relationship_status",                     default: "NEEDED"
     t.string   "struct_metadata_status"
     t.text     "object",                 limit: 65535
     t.text     "relationships",          limit: 65535
-    t.text     "struct_metadata",        limit: 65535
+    t.text     "struct_metadata",        limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/lib/dul_hydra/migration/migrate_single_object_struct_metadata_job.rb
+++ b/lib/dul_hydra/migration/migrate_single_object_struct_metadata_job.rb
@@ -33,7 +33,7 @@ module DulHydra::Migration
     end
 
     def self.make_report(report, struct_metadata)
-      report.struct_metadata = truncate(struct_metadata.to_json, length: 62000)
+      report.struct_metadata = struct_metadata.to_json
       report.struct_metadata_status = MigrationReport::MIGRATION_SUCCESS
       report.save!
     end


### PR DESCRIPTION
…; closes #1749.

Size increased from MySQL TEXT to MySQL MEDIUMTEXT.
Also removes pre-emptive truncation of data to go into column, since this should no longer be needed.