### PR TITLE
Version 4.2.20

### DIFF
--- a/app/services/destroy_objects_and_descendants.rb
+++ b/app/services/destroy_objects_and_descendants.rb
@@ -1,0 +1,12 @@
+class DestroyObjectsAndDescendants
+  def self.call(pids)
+    pids.each do |pid|
+      obj = ActiveFedora::Base.find(pid)
+      if obj.respond_to?(:child_ids)
+        call(obj.child_ids)
+      end
+      obj.destroy
+      puts "#{obj.model_pid} destroyed."
+    end
+  end
+end

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "4.2.19"
+  VERSION = "4.2.20"
 end

--- a/lib/tasks/dul_hydra.rake
+++ b/lib/tasks/dul_hydra.rake
@@ -22,6 +22,18 @@ namespace :dul_hydra do
     end
   end
 
+  desc "Destroy object listed in file, one PID per line, and their descendants"
+  task :destroy_objects, [:infile] => :environment do |t, args|
+    pids = File.readlines(args[:infile]).map(&:chomp)
+    print "#{pids.length} objects and their descendants will be destroyed! Proceed? [y/N] "
+    if STDIN.gets.strip == 'y'
+      puts "Destroying objects!"
+      DestroyObjectsAndDescendants.call(pids)
+    else
+      puts "Task aborted."
+    end
+  end
+
   namespace :config do
     desc "Copy sample config files"
     task :samples do

--- a/spec/services/destroy_objects_and_descendants_spec.rb
+++ b/spec/services/destroy_objects_and_descendants_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe DestroyObjectsAndDescendants do
+
+  before {
+    @collection = FactoryGirl.create(:collection)
+    @item_no_children = FactoryGirl.create(:item)
+    @item_with_children = FactoryGirl.create(:item, :has_part)
+    @component = @item_with_children.children.first
+    @collection.children << @item_no_children
+    @collection.children << @item_with_children
+    @collection.save!
+  }
+
+  specify {
+    described_class.call([@collection.pid])
+    expect { @collection.reload }.to raise_error(ActiveFedora::ObjectNotFoundError)
+    expect { @component.reload }.to raise_error(ActiveFedora::ObjectNotFoundError)
+    expect { @item_no_children.reload }.to raise_error(ActiveFedora::ObjectNotFoundError)
+    expect { @item_with_children.reload }.to raise_error(ActiveFedora::ObjectNotFoundError)
+  }
+
+end


### PR DESCRIPTION
- Adds `DestroyObjectsAndDescendants` service
- Adds task dul_hydra:destroy_objects[infile] which takes a file of
  PIDS and sends to `DestroyObjectsAndDescendants.call(pids)`.