### PR TITLE
Create update event when permanent ID is assigned.

### DIFF
--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -14,3 +14,5 @@ ActiveSupport::Notifications.subscribe(/workflow/) do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
   PermanentId.update!(event.payload[:pid])
 end
+
+ActiveSupport::Notifications.subscribe("assign.permanent_id", Ddr::Events::UpdateEvent)


### PR DESCRIPTION
This maintains the behavior in Ddr::Managers::PermanentIdManager,
which is now deprecated.

Permanent ID assignment also assigns permanent_url to the repo object.