### PR TITLE
Adds `auto_update_permanent_id` setting to DulHydra.

### DIFF
--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -3,28 +3,9 @@ ActiveSupport::Notifications.subscribe("save.collection") do |*args|
   ReindexCollectionContents.trigger(event)
 end
 
-ActiveSupport::Notifications.subscribe(/^create\.\w+/) do |*args|
-  if DulHydra.auto_assign_permanent_id
-    event = ActiveSupport::Notifications::Event.new(*args)
-    PermanentId.assign!(event.payload[:pid])
-  end
-end
-
-ActiveSupport::Notifications.subscribe(/workflow/) do |*args|
-  event = ActiveSupport::Notifications::Event.new(*args)
-  PermanentId.update!(event.payload[:pid])
-end
+ActiveSupport::Notifications.subscribe(/^create\.\w+/, PermanentId)
+ActiveSupport::Notifications.subscribe(/^deaccession\.\w+/, PermanentId)
+ActiveSupport::Notifications.subscribe(/^destroy\.\w+/, PermanentId)
+ActiveSupport::Notifications.subscribe(/workflow/, PermanentId)
 
 ActiveSupport::Notifications.subscribe("assign.permanent_id", Ddr::Events::UpdateEvent)
-
-ActiveSupport::Notifications.subscribe(/^deaccession\.\w+/) do |*args|
-  event = ActiveSupport::Notifications::Event.new(*args)
-  pid, ark, reason = event.payload.values_at(:pid, :permanent_id, :reason)
-  PermanentId.deaccession!(pid, ark, reason) if ark
-end
-
-ActiveSupport::Notifications.subscribe(/^destroy\.\w+/) do |*args|
-  event = ActiveSupport::Notifications::Event.new(*args)
-  pid, ark, reason = event.payload.values_at(:pid, :permanent_id, :reason)
-  PermanentId.delete!(pid, ark, reason) if ark
-end

--- a/lib/dul_hydra/configurable.rb
+++ b/lib/dul_hydra/configurable.rb
@@ -47,7 +47,7 @@ module DulHydra
       mattr_accessor :alert_message_context
 
       mattr_accessor :fixity_check_limit do
-        ENV["FIXITY_CHECK_LIMIT"] || 10**5
+        ENV["FIXITY_CHECK_LIMIT"] || 10**4
       end
 
       mattr_accessor :fixity_check_period_in_days do
@@ -80,6 +80,9 @@ module DulHydra
         false
       end
 
+      mattr_accessor :auto_update_permanent_id do
+        false
+      end
     end
 
     module ClassMethods

--- a/spec/lib/dul_hydra_spec.rb
+++ b/spec/lib/dul_hydra_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe DulHydra do
+
+  describe "configuration defaults" do
+    subject { described_class }
+    its(:auto_assign_permanent_id) { is_expected.to be false }
+    its(:auto_update_permanent_id) { is_expected.to be false }
+    its(:fixity_check_limit) { is_expected.to eq(10000) }
+    its(:fixity_check_period_in_days) { is_expected.to eq(60) }
+    its(:batches_per_page) { is_expected.to eq(10) }
+  end
+
+end


### PR DESCRIPTION
Adds PermanentId.call to handle ActiveSupport notification events.