### PR TITLE
Removes `md5` column from `FileDigest`.

### DIFF
--- a/app/models/file_digest.rb
+++ b/app/models/file_digest.rb
@@ -2,33 +2,16 @@ require 'digest'
 
 class FileDigest < ActiveRecord::Base
 
-  class_attribute :algorithms
-  self.algorithms = %w( md5 sha1 ).freeze
+  validates_presence_of :repo_id, :file_id, :sha1
 
-  module Algorithms
-    FileDigest.algorithms.each do |algo|
-      define_method "generate_#{algo}" do |file_path|
-        algo_class = Digest.const_get(algo.upcase)
-        algo_class.file(file_path).hexdigest
-      end
-    end
+  def self.generate_sha1(path)
+    Digest::SHA1.file(path).hexdigest
   end
 
-  extend Algorithms
-  include Algorithms
+  delegate :generate_sha1, to: :class
 
-  validates_presence_of :repo_id, :file_id
-
-  def set_digests(file_path)
-    algorithms.each { |algo| set_digest(algo, file_path) }
-  end
-
-  def set_digest(algorithm, file_path)
-    write_attribute algorithm, send("generate_#{algorithm}", file_path)
-  end
-
-  def digests_changed?
-    (changed & algorithms).any?
+  def set_digest(path)
+    self.sha1 = generate_sha1(path)
   end
 
 end

--- a/app/services/file_digest_manager.rb
+++ b/app/services/file_digest_manager.rb
@@ -20,22 +20,18 @@ class FileDigestManager
 
   def self.add_or_update(repo_id, file_id, file_path)
     file_digest = FileDigest.find_or_initialize_by(repo_id: repo_id, file_id: file_id)
-    file_digest.set_digests(file_path)
-    if file_digest.digests_changed?
-      file_digest.save
+    file_digest.set_digest(file_path)
+    if file_digest.sha1_changed?
+      file_digest.save!
     else
       false
     end
   end
 
   def self.delete(repo_id, file_id = nil)
-    if file_id
-      if file_digest = FileDigest.find_by_repo_id_and_file_id(repo_id, file_id)
-        file_digest.destroy
-      end
-    else
-      FileDigest.where(repo_id: repo_id).destroy_all
-    end
+    conditions = { repo_id: repo_id }
+    conditions.merge!(file_id: file_id) if file_id
+    FileDigest.where(conditions).destroy_all
   end
 
 end

--- a/db/migrate/20170222193520_remove_md5_from_file_digests.rb
+++ b/db/migrate/20170222193520_remove_md5_from_file_digests.rb
@@ -1,0 +1,7 @@
+require_relative '20170216210541_add_md5_to_file_digests'
+
+class RemoveMd5FromFileDigests < ActiveRecord::Migration
+  def change
+    revert AddMd5ToFileDigests
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216210541) do
+ActiveRecord::Schema.define(version: 20170222193520) do
 
   create_table "batch_object_attributes", force: :cascade do |t|
     t.integer  "batch_object_id"
@@ -161,10 +161,9 @@ ActiveRecord::Schema.define(version: 20170216210541) do
     t.string   "sha1"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "md5"
   end
 
-  add_index "file_digests", ["repo_id", "file_id"], name: "index_file_digests_on_repo_id_and_file_id", unique: true
+  add_index "file_digests", ["repo_id", "file_id"], name: "index_file_digests_on_repo_id_and_file_id"
 
   create_table "ingest_folders", force: :cascade do |t|
     t.integer  "user_id"

--- a/spec/models/file_digest_spec.rb
+++ b/spec/models/file_digest_spec.rb
@@ -11,20 +11,10 @@ RSpec.describe FileDigest do
     }
   end
 
-  describe "generate_md5" do
-    specify {
-      expect(described_class.generate_md5(file.path)).to eq "4f3f9c99a9f2720b77870371ff21ea9f"
-    }
-    specify {
-      expect(subject.generate_md5(file.path)).to eq "4f3f9c99a9f2720b77870371ff21ea9f"
-    }
-  end
-
-  describe "set_digests" do
+  describe "set_digest" do
     before do
-      subject.set_digests(file.path)
+      subject.set_digest(file.path)
     end
-    its(:md5) { is_expected.to eq "4f3f9c99a9f2720b77870371ff21ea9f" }
     its(:sha1) { is_expected.to eq "a6ae0d815c1a2aef551b45fe34a35ceea1828a4d" }
   end
 

--- a/spec/services/file_digest_manager_spec.rb
+++ b/spec/services/file_digest_manager_spec.rb
@@ -1,37 +1,24 @@
 RSpec.describe FileDigestManager do
 
-  before(:all) do
-    class TestFileDigestManager < Ddr::Models::Base
-      include Ddr::Models::HasContent
-      include Ddr::Models::Describable
-      has_file_datastream name: "e_content", control_group: "E"
-    end
-  end
-
-  after(:all) do
-    Object.send(:remove_const, :TestFileDigestManager)
-  end
-
   before(:each) do
     file = fixture_file_upload('sample.pdf')
     obj.descMetadata.title = [ "Title" ]
-    obj.e_content.dsLocation = Ddr::Utils.path_to_uri(file.path)
+    obj.content.dsLocation = Ddr::Utils.path_to_uri(file.path)
     obj.save!
   end
 
-  let(:obj) { TestFileDigestManager.new(pid: 'testfdm:1') }
+  let(:obj) { Component.new(pid: 'testfdm:1') }
 
   it "creates a file digest for external files" do
-    file_digest = FileDigest.find_by_repo_id_and_file_id!('testfdm:1', 'e_content')
+    file_digest = FileDigest.find_by_repo_id_and_file_id!('testfdm:1', 'content')
     expect(file_digest.sha1).to eq "a6ae0d815c1a2aef551b45fe34a35ceea1828a4d"
-    expect(file_digest.md5).to eq "4f3f9c99a9f2720b77870371ff21ea9f"
   end
 
   it "updates the file digest for an external file" do
     new_file = fixture_file_upload('sample.docx')
-    file_digest = FileDigest.find_by_repo_id_and_file_id!('testfdm:1', 'e_content')
+    file_digest = FileDigest.find_by_repo_id_and_file_id!('testfdm:1', 'content')
     expect {
-      obj.e_content.dsLocation = Ddr::Utils.path_to_uri(new_file.path)
+      obj.content.dsLocation = Ddr::Utils.path_to_uri(new_file.path)
       obj.save!
       file_digest.reload
     }.to change(file_digest, :sha1).to("ff01aab0eada29d35bb423c5c73a9f67a22bc1fd")
@@ -47,8 +34,8 @@ RSpec.describe FileDigestManager do
   end
 
   it "deletes the file digest when the datastream is deleted" do
-    obj.e_content.delete
-    expect(FileDigest.where(repo_id: obj.id)).to be_empty
+    obj.content.delete
+    expect(FileDigest.where(repo_id: obj.id, file_id: 'content')).to be_empty
   end
 
 end


### PR DESCRIPTION
Effectively reverts changes in commit 38f12a25efd4b9a420777f97bddb662f6d39efcf.