### PR TITLE
Hotfix version 4.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,12 @@ gem 'hydra-head', '7.2.2'
 gem 'blacklight', '5.19.2'
 gem 'ddr-alerts', '~> 1.0.0'
 gem 'ddr-batch', '1.2.0'
-gem 'ddr-models', '2.6.1'
+gem 'ddr-models', '2.6.2'
 gem 'rubydora', '>= 1.9.1'
 gem 'devise'
 gem 'deprecation'
 gem 'virtus', '~> 1.0.5'
+gem 'ezid-client', '~> 1.7'
 
 gem 'log4r'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,14 +96,14 @@ GEM
       log4r
       paperclip (~> 4.2.0)
       rails (~> 4.1.13)
-    ddr-models (2.6.1)
+    ddr-models (2.6.2)
       active-fedora (~> 7.0)
       activeresource
       cancancan (~> 1.12)
       ddr-antivirus (~> 2.1.1)
       devise (~> 3.4)
       edtf (~> 3.0)
-      ezid-client (~> 1.4.2)
+      ezid-client (~> 1.6)
       grouper-rest-client
       hashie (~> 3.4, < 3.4.4)
       hydra-core (~> 7.2)
@@ -131,15 +131,15 @@ GEM
     ebnf (0.3.9)
       rdf (~> 1.1)
       sxp (~> 0.1, >= 0.1.3)
-    edtf (3.0.0)
+    edtf (3.0.1)
       activesupport (>= 3.0, < 6.0)
     equalizer (0.0.11)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
     execjs (2.7.0)
-    ezid-client (1.4.3)
-      hashie
+    ezid-client (1.7.0)
+      hashie (~> 3.4, >= 3.4.3)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.8.0)
@@ -226,7 +226,7 @@ GEM
     nest (1.1.2)
       redis
     net-http-persistent (2.9.4)
-    net-ldap (0.15.0)
+    net-ldap (0.16.0)
     netrc (0.11.0)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
@@ -457,10 +457,11 @@ DEPENDENCIES
   database_cleaner
   ddr-alerts (~> 1.0.0)
   ddr-batch (= 1.2.0)
-  ddr-models (= 2.6.1)
+  ddr-models (= 2.6.2)
   deprecation
   devise
   equivalent-xml
+  ezid-client (~> 1.7)
   factory_girl_rails
   hydra-head (= 7.2.2)
   jettywrapper (~> 1.8)

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "4.5.1"
+  VERSION = "4.5.2"
 end


### PR DESCRIPTION
- Upgrades ddr-models to v2.6.2.
- Upgrades ezid-client to v1.7.0.