### PR TITLE
Hotfix 4.6.3

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -2,6 +2,22 @@ class DownloadsController < ApplicationController
 
   include Hydra::Controller::DownloadBehavior
 
+  def send_content
+    datastream.external? ? send_external_content : super
+  end
+
+  def send_external_content
+    if request.head?
+      head :ok,
+           content_length: datastream.file_size,
+           content_type: datastream.mimeType
+    else
+      send_file datastream.file_path,
+                type: datastream.mimeType,
+                filename: datastream_name
+    end
+  end
+
   def load_asset
     # XXX Loading instance from solr doesn't work with customized datastream_name (below).
     @asset = ActiveFedora::Base.find(params[asset_param_key])

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "4.6.2"
+  VERSION = "4.6.3"
 end


### PR DESCRIPTION
Fixes DownloadsController to use `send_file` for external content.