### PR TITLE
Warn and do not create batch when no ingestable files.  DDR-469.

### DIFF
--- a/app/controllers/ingest_folders_controller.rb
+++ b/app/controllers/ingest_folders_controller.rb
@@ -34,7 +34,8 @@ class IngestFoldersController < ApplicationController
   end
 
   def procezz
-    @ingest_folder.procezz
+    msg = @ingest_folder.procezz
+    flash[:notice] = msg
     redirect_to :controller => :batches, :action => :index
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
               rows: Rows (excludes header row)
   batch:
       ingest_folder:
+          batch_created: "Batch %{batch_id} created"
           batch_name: Folder Ingest
           base_path:
               forbidden: "%{path} is not permitted for folder ingest"
@@ -172,6 +173,8 @@ en:
           creating_batch: Creating Ingest Batch ...
           excluded_files: Excluded Files
           folder: Folder
+          no_batch_created: "No batch was created: %{reason}"
+          no_ingestable_files: "%{path} does not contain any ingestable files"
           not_readable: "%{path} does not exist or is not readable"
           objects_to_ingest: Objects to be Ingested
           scan_folder: Scan Folder


### PR DESCRIPTION
Also removes some old cruft from before current admin_policy handling.