### PR TITLE
Hotfix v4.6.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.7'
 
 gem 'ddr-alerts', '1.1.0'
 gem 'ddr-batch', '1.3.0'
-gem 'ddr-models', '2.7.5'
+gem 'ddr-models', '2.7.6'
 
 gem 'hydra-head', '7.2.2'
 gem 'blacklight', '5.19.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       log4r
       paperclip (~> 4.2.0)
       rails (~> 4.1)
-    ddr-models (2.7.5)
+    ddr-models (2.7.6)
       active-fedora (>= 7.3.1, < 8)
       activeresource
       cancancan (~> 1.12)
@@ -510,7 +510,7 @@ DEPENDENCIES
   database_cleaner
   ddr-alerts (= 1.1.0)
   ddr-batch (= 1.3.0)
-  ddr-models (= 2.7.5)
+  ddr-models (= 2.7.6)
   deprecation
   devise
   equivalent-xml

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "4.6.7"
+  VERSION = "4.6.8"
 end


### PR DESCRIPTION
Upgrades ddr-models to v2.7.6.