### PR TITLE
Adds `affiliation` as editable admin metadata field.

### DIFF
--- a/lib/dul_hydra/configurable.rb
+++ b/lib/dul_hydra/configurable.rb
@@ -60,6 +60,7 @@ module DulHydra
 
       mattr_accessor :user_editable_admin_metadata_fields do
         [
+          :affiliation,
           :aleph_id,
           :aspace_id,
           :depositor,


### PR DESCRIPTION
Finishes work of DDR-872.