### PR TITLE
Revert "Adds md5 and path columns to file_digests. (#1878)"

### DIFF
--- a/app/models/file_digest.rb
+++ b/app/models/file_digest.rb
@@ -2,21 +2,22 @@ require 'digest'
 
 class FileDigest < ActiveRecord::Base
 
-  validates_presence_of :repo_id, :file_id, :path
+  validates_presence_of :repo_id, :file_id, :sha1
+
+  def self.sha1(repo_id, file_id)
+    if fd = find_by(repo_id: repo_id, file_id: file_id)
+      fd.sha1
+    end
+  end
 
   def self.generate_sha1(path)
     Digest::SHA1.file(path).hexdigest
   end
 
-  def self.generate_md5(path)
-    Digest::MD5.file(path).hexdigest
-  end
+  delegate :generate_sha1, to: :class
 
-  delegate :generate_sha1, :generate_md5, to: :class
-
-  def set_digests
+  def set_digest(path)
     self.sha1 = generate_sha1(path)
-    self.md5  = generate_md5(path)
   end
 
 end

--- a/app/services/file_digest_manager.rb
+++ b/app/services/file_digest_manager.rb
@@ -20,9 +20,12 @@ class FileDigestManager
 
   def self.add_or_update(repo_id, file_id, file_path)
     file_digest = FileDigest.find_or_initialize_by(repo_id: repo_id, file_id: file_id)
-    file_digest.path = file_path
-    file_digest.set_digests
-    file_digest.save!
+    file_digest.set_digest(file_path)
+    if file_digest.sha1_changed?
+      file_digest.save!
+    else
+      false
+    end
   end
 
   def self.delete(repo_id, file_id = nil)

--- a/db/migrate/20170606140633_remove_columns_from_file_digests.rb
+++ b/db/migrate/20170606140633_remove_columns_from_file_digests.rb
@@ -1,0 +1,6 @@
+class RemoveColumnsFromFileDigests < ActiveRecord::Migration
+  def change
+    remove_column :file_digests, :md5, :string
+    remove_column :file_digests, :path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170605205141) do
+ActiveRecord::Schema.define(version: 20170606140633) do
 
   create_table "batch_object_attributes", force: :cascade do |t|
     t.integer  "batch_object_id"
@@ -160,8 +160,6 @@ ActiveRecord::Schema.define(version: 20170605205141) do
     t.string   "sha1"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "path"
-    t.string   "md5"
   end
 
   add_index "file_digests", ["repo_id", "file_id"], name: "index_file_digests_on_repo_id_and_file_id"

--- a/spec/models/file_digest_spec.rb
+++ b/spec/models/file_digest_spec.rb
@@ -1,42 +1,40 @@
 RSpec.describe FileDigest do
 
-  subject { described_class.new(path: file.path, repo_id: "test:1", file_id: "content") }
-
   let(:file) { fixture_file_upload('sample.pdf') }
-
   let(:sha1) { 'a6ae0d815c1a2aef551b45fe34a35ceea1828a4d' }
-  let(:md5) { '4f3f9c99a9f2720b77870371ff21ea9f' }
 
-  describe ".generate_sha1" do
+  describe "sha1" do
+    let(:repo_id) { 'test:1' }
+    let(:file_id) { 'content' }
+    describe "record exists" do
+      before do
+        described_class.create(repo_id: 'test:1', file_id: 'content', sha1: sha1)
+      end
+      specify {
+        expect(described_class.sha1(repo_id, file_id)).to eq sha1
+      }
+    end
+    describe "record does not exist" do
+      specify {
+        expect(described_class.sha1(repo_id, file_id)).to be nil
+      }
+    end
+  end
+
+  describe "generate_sha1" do
     specify {
       expect(described_class.generate_sha1(file.path)).to eq sha1
     }
-  end
-
-  describe "#generate_sha1" do
     specify {
       expect(subject.generate_sha1(file.path)).to eq sha1
     }
   end
 
-  describe ".generate_md5" do
-    specify {
-      expect(described_class.generate_md5(file.path)).to eq md5
-    }
-  end
-
-  describe "#generate_md5" do
-    specify {
-      expect(subject.generate_md5(file.path)).to eq md5
-    }
-  end
-
-  describe "set_digests" do
+  describe "set_digest" do
     before do
-      subject.set_digests
+      subject.set_digest(file.path)
     end
     its(:sha1) { is_expected.to eq sha1 }
-    its(:md5) { is_expected.to eq md5 }
   end
 
 end

--- a/spec/services/file_digest_manager_spec.rb
+++ b/spec/services/file_digest_manager_spec.rb
@@ -1,22 +1,20 @@
 RSpec.describe FileDigestManager do
 
   before(:each) do
+    file = fixture_file_upload('sample.pdf')
     obj.descMetadata.title = [ "Title" ]
     obj.content.dsLocation = Ddr::Utils.path_to_uri(file.path)
     obj.save!
   end
 
-  let(:file) { fixture_file_upload('sample.pdf') }
   let(:obj) { Component.new(pid: 'testfdm:1') }
 
-  it "creates sha1 and md5 digests for external files" do
+  it "creates a file digest for external files" do
     file_digest = FileDigest.find_by_repo_id_and_file_id!('testfdm:1', 'content')
-    expect(file_digest.path).to eq file.path
     expect(file_digest.sha1).to eq "a6ae0d815c1a2aef551b45fe34a35ceea1828a4d"
-    expect(file_digest.md5).to eq "4f3f9c99a9f2720b77870371ff21ea9f"
   end
 
-  it "updates the sha1 digest for an external file" do
+  it "updates the file digest for an external file" do
     new_file = fixture_file_upload('sample.docx')
     file_digest = FileDigest.find_by_repo_id_and_file_id!('testfdm:1', 'content')
     expect {
@@ -24,26 +22,6 @@ RSpec.describe FileDigestManager do
       obj.save!
       file_digest.reload
     }.to change(file_digest, :sha1).to("ff01aab0eada29d35bb423c5c73a9f67a22bc1fd")
-  end
-
-  it "updates the md5 digest for an external file" do
-    new_file = fixture_file_upload('sample.docx')
-    file_digest = FileDigest.find_by_repo_id_and_file_id!('testfdm:1', 'content')
-    expect {
-      obj.content.dsLocation = Ddr::Utils.path_to_uri(new_file.path)
-      obj.save!
-      file_digest.reload
-    }.to change(file_digest, :md5).to("b0181c7f5fb49b08ec3a9768c9fd07b4")
-  end
-
-  it "updates the path for an external file" do
-    new_file = fixture_file_upload('sample.docx')
-    file_digest = FileDigest.find_by_repo_id_and_file_id!('testfdm:1', 'content')
-    expect {
-      obj.content.dsLocation = Ddr::Utils.path_to_uri(new_file.path)
-      obj.save!
-      file_digest.reload
-    }.to change(file_digest, :path)
   end
 
   it "does not create a file digest for non-external files" do


### PR DESCRIPTION
This reverts commit e36c6365eb18f7b0ddf12e9675d90d97489195b0.

Note that the database migration was not removed; a new migration
removing the added columns was added; so, this is not a true
revert of the commit.