### PR TITLE
Rename helper methods to permit collisions; DDR-1121.

### DIFF
--- a/app/helpers/ingest_folders_helper.rb
+++ b/app/helpers/ingest_folders_helper.rb
@@ -1,6 +1,6 @@
 module IngestFoldersHelper
 
-  def permitted_folder_bases
+  def permitted_ingest_folder_bases
     IngestFolder.permitted_folders(current_user)
   end
 

--- a/app/helpers/nested_folder_ingest_helper.rb
+++ b/app/helpers/nested_folder_ingest_helper.rb
@@ -8,7 +8,7 @@ module NestedFolderIngestHelper
     NestedFolderIngest.default_checksum_location
   end
 
-  def permitted_folder_bases
+  def permitted_nested_folder_ingest_bases
     NestedFolderIngest.default_basepaths
   end
 

--- a/app/views/ingest_folders/new.html.erb
+++ b/app/views/ingest_folders/new.html.erb
@@ -21,7 +21,7 @@
     </div>
 		<div class="form-group">
 			<%= f.label :base_path %>
-			<%= f.select :base_path, options_for_select(permitted_folder_bases), {}, {class: 'form-control'} %>
+			<%= f.select :base_path, options_for_select(permitted_ingest_folder_bases), {}, {class: 'form-control'} %>
 		</div>
 		<div class="form-group">
 			<%= f.label :sub_path %>

--- a/app/views/nested_folder_ingests/_folder_path.html.erb
+++ b/app/views/nested_folder_ingests/_folder_path.html.erb
@@ -1,10 +1,10 @@
 <div class="form-group">
   <%= f.label :basepath %>
-  <% if permitted_folder_bases.size == 1 %>
-      <%= f.hidden_field :basepath, value: permitted_folder_bases.first %>
-      <%= permitted_folder_bases.first %>
+  <% if permitted_nested_folder_ingest_bases.size == 1 %>
+      <%= f.hidden_field :basepath, value: permitted_nested_folder_ingest_bases.first %>
+      <%= permitted_nested_folder_ingest_bases.first %>
   <% else %>
-      <%= f.select :basepath, options_for_select(permitted_folder_bases), {prompt: true}, {class: 'form-control'} %>
+      <%= f.select :basepath, options_for_select(permitted_nested_folder_ingest_bases), {prompt: true}, {class: 'form-control'} %>
   <% end %>
 </div>
 <div class="form-group">


### PR DESCRIPTION
If the same method name is used in more than one application helpers, Rails uses the
method occurring in the helper that has the last name alphabetically.