### PR TITLE
Adds code to address DDR-1128.

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -47,6 +47,7 @@ class CollectionsController < ApplicationController
           filename: params.require(:filename) + ".csv",
           notify: params.require(:notify),
           user: current_user.aspace_username,
+          debug: !!params[:debug],
         }
         ArchivesSpace::CreateDigitalObjectsJob.perform_later(current_object.id, options)
       end

--- a/app/jobs/archives_space/create_digital_objects_job.rb
+++ b/app/jobs/archives_space/create_digital_objects_job.rb
@@ -5,7 +5,7 @@ module ArchivesSpace
 
     def perform(collection_id, options)
       csv = ArchivesSpace::ExportDigitalObjectInfo.call(collection_id).csv
-      output = ArchivesSpace::CreateDigitalObjects.call(csv, options.slice(:user, :publish))
+      output = ArchivesSpace::CreateDigitalObjects.call(csv, options.slice(:user, :publish, :debug))
       subject = "REPORT: Create Digital Objects for #{collection_id}"
       message = "The report is attached."
       ::ReportMailer.basic(

--- a/app/services/archives_space/export_digital_object_info.rb
+++ b/app/services/archives_space/export_digital_object_info.rb
@@ -2,7 +2,7 @@ module ArchivesSpace
   class ExportDigitalObjectInfo
 
     title_field = Ddr::Index::Fields.descmd.detect { |f| f == "title_tesim" } # HACK
-    FIELDS = [ :id, :aspace_id, :permanent_id, :permanent_url, :display_format, title_field ]
+    FIELDS = [ :id, :aspace_id, :ead_id, :permanent_id, :permanent_url, :display_format, title_field ]
 
     def self.call(collection_id)
       Ddr::Index::Query.build(collection_id) do |coll|

--- a/app/views/collections/_aspace_form.html.erb
+++ b/app/views/collections/_aspace_form.html.erb
@@ -22,5 +22,11 @@
   <label for="filename">Report filename - not including .csv extension</label>
   <%= text_field_tag "filename", @filename, style: "width: 50%", class: "form-control" %>
 </div>
+<div class="checkbox">
+  <label>
+    <%= check_box_tag "debug" %>
+    Debug (will not make changes in ArchivesSpace)
+  </label>
+</div>
 <button type="submit" class="btn btn-primary">Submit</button>
 <% end %>


### PR DESCRIPTION
In some cases, the aspace_id in the repository points to multiple
archival objects in ASpace (which is not supposed to be the case).
The digital object creation process must in those cases check
that the "resource" that the AO is part of is associated with the
correct EAD ID as recroded on the repository item.

A debug option was added to the DO creation form to support
dry runs on production that do not make changes in ASpace.