### PR TITLE
Add Caption datastream to datastream upload functionality; DDR-1140.

### DIFF
--- a/app/models/datastream_upload.rb
+++ b/app/models/datastream_upload.rb
@@ -12,7 +12,8 @@ class DatastreamUpload
   DEFAULT_CONFIG_FILE = Rails.root.join('config', 'datastream_upload.yml')
 
   validates_presence_of :basepath, :datastream_name, :subpath, :user
-  validates_inclusion_of :datastream_name, in: [ Ddr::Datastreams::INTERMEDIATE_FILE,
+  validates_inclusion_of :datastream_name, in: [ Ddr::Datastreams::CAPTION,
+                                                 Ddr::Datastreams::INTERMEDIATE_FILE,
                                                  Ddr::Datastreams::STREAMABLE_MEDIA ]
   validate :folder_directory_must_exist, if: [ 'basepath.present?', 'subpath.present?' ]
   validate :checksum_path_must_exist, if: 'checksum_file.present?'
@@ -61,7 +62,7 @@ class DatastreamUpload
         datastream_name: datastream_name,
         filesystem: filesystem
     }
-    builder_args.merge!(checksum_file_path: checksum_path) if checksum_file
+    builder_args.merge!(checksum_file_path: checksum_path) if checksum_file.present?
     builder_args.merge!(collection: collection_id) if collection_id
     batch_builder = BuildBatchFromDatastreamUpload.new(builder_args)
     batch_builder.call

--- a/app/views/collections/_actions.html.erb
+++ b/app/views/collections/_actions.html.erb
@@ -21,6 +21,12 @@
   </li>
   <li class="list-group-item">
     <%= link_to_if can?(:upload, current_object),
+                   'Upload Caption Files',
+                   new_datastream_upload_path(datastream_upload: { collection_id: current_object, datastream_name: Ddr::Datastreams::CAPTION })
+    %>
+  </li>
+  <li class="list-group-item">
+    <%= link_to_if can?(:upload, current_object),
                    'Upload Intermediate Files',
                    new_datastream_upload_path(datastream_upload: { collection_id: current_object, datastream_name: Ddr::Datastreams::INTERMEDIATE_FILE })
     %>

--- a/config/datastream_upload.yml.sample
+++ b/config/datastream_upload.yml.sample
@@ -1,3 +1,13 @@
+caption:
+  basepaths:
+    - /dir/path
+    - /dir/other/path
+  scanner:
+    exclude:
+      - .DS_Store
+      - Thumbs.db
+  checksums:
+    location: /path/to/checksums/dir
 intermediateFile:
   basepaths:
     - /dir/path

--- a/spec/fixtures/batch_update/datastream_upload/datastream_upload.yml
+++ b/spec/fixtures/batch_update/datastream_upload/datastream_upload.yml
@@ -1,3 +1,13 @@
+caption:
+  basepaths:
+    - /dir/path
+    - /dir/other/path
+  scanner:
+    exclude:
+      - .DS_Store
+      - Thumbs.db
+  checksums:
+    location: /path/to/checksums/dir
 intermediateFile:
   basepaths:
     - /dir/path


### PR DESCRIPTION
Datastream upload now works for caption files, intermediate files, and streamable media files.
Also fixes bug in DatastreamUpload that occurred if checksum file not provided.