### PR TITLE
Calculate default structural metadata when object is created; DDR-1146.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.7'
 
 gem 'ddr-alerts', '1.1.0'
 gem 'ddr-batch', '1.4.1'
-gem 'ddr-models', github: 'duke-libraries/ddr-models', ref: '3a84a708017a52a089aaa05d1c75f10c1ea77688'
+gem 'ddr-models', github: 'duke-libraries/ddr-models', ref: 'cdef58e9a2fa8e1a490b39c10273f0264f9c48a6'
 
 gem 'hydra-head', '7.2.2'
 gem 'blacklight', '5.19.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/duke-libraries/ddr-models.git
-  revision: 3a84a708017a52a089aaa05d1c75f10c1ea77688
-  ref: 3a84a708017a52a089aaa05d1c75f10c1ea77688
+  revision: cdef58e9a2fa8e1a490b39c10273f0264f9c48a6
+  ref: cdef58e9a2fa8e1a490b39c10273f0264f9c48a6
   specs:
     ddr-models (2.9.0.pre)
       active-fedora (>= 7.3.1, < 8)

--- a/app/services/set_default_structure.rb
+++ b/app/services/set_default_structure.rb
@@ -1,0 +1,36 @@
+class SetDefaultStructure
+
+  attr_reader :object
+
+  def self.call(*args)
+    event = ActiveSupport::Notifications::Event.new(*args)
+    service = SetDefaultStructure.new(event.payload[:pid])
+    service.enqueue_default_structure_job
+  end
+
+  def initialize(repo_id)
+    @object = ActiveFedora::Base.find(repo_id)
+  end
+
+  def enqueue_default_structure_job
+    if default_structure_needed?
+      Resque.enqueue(GenerateDefaultStructureJob, object.id)
+    end
+  end
+
+  def default_structure_needed?
+    if object.can_have_struct_metadata?
+      if object.has_struct_metadata?
+        if object.structure.repository_maintained?
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    else
+      false
+    end
+  end
+end

--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -1,5 +1,9 @@
 ActiveSupport::Notifications.subscribe("success.batch.batch.ddr", SetDefaultStructuresAfterSuccessfulBatchIngest)
 
+ActiveSupport::Notifications.subscribe(Ddr::Models::Base::INGEST) do |*args|
+  SetDefaultStructure.call(*args) if [ "Collection", "Item", "Component" ].include?(args.last[:model])
+end
+
 ActiveSupport::Notifications.subscribe(Ddr::Models::Base::UPDATE) do |*args|
   ReindexCollectionContents.call(*args) if args.last[:model] == "Collection"
 end

--- a/spec/services/set_default_structure_spec.rb
+++ b/spec/services/set_default_structure_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe SetDefaultStructure, type: :service do
+
+  subject { described_class.new(repo_id) }
+
+  let(:repo_id) { 'test:1234' }
+
+  before do
+    allow(ActiveFedora::Base).to receive(:find) { object }
+  end
+
+  describe '#default_structure_needed?' do
+    describe 'can have structural metadata' do
+      describe 'no existing structural metadata' do
+        let(:object) { double(can_have_struct_metadata?: true, has_struct_metadata?: false) }
+        its(:default_structure_needed?) { is_expected.to be true }
+      end
+      describe 'existing structural metadata' do
+        let(:object) { double(can_have_struct_metadata?: true, has_struct_metadata?: true) }
+        describe 'repository maintained' do
+          before { allow(object).to receive_message_chain(:structure, :repository_maintained?) { true } }
+          its(:default_structure_needed?) { is_expected.to be true }
+        end
+        describe 'not repository maintained' do
+          before { allow(object).to receive_message_chain(:structure, :repository_maintained?) { false } }
+          its(:default_structure_needed?) { is_expected.to be false }
+        end
+      end
+    end
+    describe 'cannot have structural metadata' do
+      let(:object) { double(can_have_struct_metadata?: false) }
+      its(:default_structure_needed?) { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
Typically, there will be no structurally relevant entities at the time of object creation
but this PR covers the case if there are.