### PR TITLE
Removes DuraCloud tab from staff UI.

### DIFF
--- a/app/controllers/concerns/dul_hydra/controller/repository_behavior.rb
+++ b/app/controllers/concerns/dul_hydra/controller/repository_behavior.rb
@@ -17,7 +17,7 @@ module DulHydra
         include Blacklight::Base
         include DulHydra::Controller::TabbedViewBehavior
 
-        self.tabs = [ :tab_descriptive_metadata, :tab_admin_metadata, :tab_roles, :tab_duracloud ]
+        self.tabs = [ :tab_descriptive_metadata, :tab_admin_metadata, :tab_roles ]
 
         helper_method :current_object
         helper_method :current_document


### PR DESCRIPTION
Supporting code is not removed.