### PR TITLE
Hotfix 4.8.2

### DIFF
--- a/app/services/file_characterization.rb
+++ b/app/services/file_characterization.rb
@@ -10,12 +10,10 @@ class FileCharacterization < SimpleDelegator
   end
 
   def call
-    with_content_file do |path|
-      fits_output = run_fits(path)
-      reload
-      fits.content = fits_output
-      save!
-    end
+    fits_output = run_fits(content.file_path)
+    reload
+    fits.content = fits_output
+    save!
   end
 
   private

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "4.8.1"
+  VERSION = "4.8.2"
 end


### PR DESCRIPTION
Fixes FileCharacterization service, which was broken when
`with_content_file` was removed.