### PR TITLE
Hotfix 4.8.5

### DIFF
--- a/app/services/reindex_collection_contents.rb
+++ b/app/services/reindex_collection_contents.rb
@@ -1,6 +1,6 @@
 class ReindexCollectionContents
 
-  TRIGGER_ON_CHANGED = %w( admin_set title )
+  TRIGGER_ON_DS_CHANGED = [ Ddr::Datastreams::DESC_METADATA, Ddr::Datastreams::ADMIN_METADATA ]
 
   def self.call(*args)
     if args.size > 1
@@ -18,8 +18,7 @@ class ReindexCollectionContents
 
   def self.handle_notification(*args)
     event = ActiveSupport::Notifications::Event.new(*args)
-    attributes_changed = event.payload[:attributes_changed].keys
-    if (attributes_changed & TRIGGER_ON_CHANGED).present?
+    if (event.payload[:datastreams_changed] & TRIGGER_ON_DS_CHANGED).present?
       call event.payload[:pid]
     end
   end

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "4.8.4"
+  VERSION = "4.8.5"
 end

--- a/spec/services/reindex_collection_contents_spec.rb
+++ b/spec/services/reindex_collection_contents_spec.rb
@@ -5,17 +5,24 @@ RSpec.describe ReindexCollectionContents do
       before {
         @collection = FactoryGirl.create(:collection)
       }
-      describe "when a tracked attribute changed" do
-        it "calls the service" do
-          expect(described_class).to receive(:call)
+      describe "when adminMetadata datastream changed" do
+        it "reindexes" do
+          expect(ReindexQueryResult).to receive(:call)
+          @collection.admin_set = "bar"
+          @collection.save!
+        end
+      end
+      describe "when descMetadata datastream changed" do
+        it "reindexes" do
+          expect(ReindexQueryResult).to receive(:call)
           @collection.title = [ "Title Changed" ]
           @collection.save!
         end
       end
-      describe "when no tracked attribute is changed" do
-        it "does not call the service" do
-          expect(described_class).not_to receive(:call).with(@collection.pid)
-          @collection.local_id = "001"
+      describe "when RELS-EXT datastream changed" do
+        it "does not reindex" do
+          expect(ReindexQueryResult).not_to receive(:call)
+          @collection.admin_policy = FactoryGirl.create(:collection)
           @collection.save!
         end
       end


### PR DESCRIPTION
Fixes triggering of collection contents reindexing when descriptive metadata
edited through the web.