### PR TITLE
Create UpdateContentMediaType service.

### DIFF
--- a/app/services/update_content_media_type.rb
+++ b/app/services/update_content_media_type.rb
@@ -1,0 +1,13 @@
+class UpdateContentMediaType
+
+  def self.call(*args)
+    event = ActiveSupport::Notifications::Event.new(*args)
+    obj = ActiveFedora::Base.find(event.payload[:pid])
+    if obj.techmd.media_type.length == 1 &&
+       obj.techmd.media_type.first != obj.content.mimeType
+      obj.content.mimeType = obj.techmd.media_type.first
+      obj.save!(summary: "Content media type updated from FITS information")
+    end
+  end
+
+end

--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -25,3 +25,9 @@ end
 ActiveSupport::Notifications.subscribe(Ddr::Models::Base::DELETE) do |*args|
   UpdateParentStructure.call(*args) if [ "Item", "Component" ].include?(args.last[:model])
 end
+
+ActiveSupport::Notifications.subscribe(Ddr::Datastreams::SAVE) do |*args|
+  if args.last[:file_id] == Ddr::Datastreams::FITS
+    UpdateContentMediaType.call(*args)
+  end
+end

--- a/spec/fixtures/fits.xml
+++ b/spec/fixtures/fits.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.0" timestamp="10/17/17 5:47 PM">
+  <identification>
+    <identity format="JPEG File Interchange Format" mimetype="image/jpeg" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="Droid" toolversion="6.3" />
+      <tool toolname="Jhove" toolversion="1.16" />
+      <tool toolname="file utility" toolversion="5.25" />
+      <tool toolname="Exiftool" toolversion="10.00" />
+      <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
+      <version toolname="Droid" toolversion="6.3">1.01</version>
+      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/43</externalIdentifier>
+    </identity>
+  </identification>
+  <fileinfo>
+    <size toolname="Jhove" toolversion="1.16">97220</size>
+    <creatingApplicationName toolname="Jhove" toolversion="1.16">File source: https://commons.wikimedia.org/wiki/File:Dante_Gabriel_Rossetti_-_Joan_of_Arc_(1882).jpg</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dc/Downloads/Dante_Gabriel_Rossetti_-_Joan_of_Arc_(1882).jpg</filepath>
+    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Dante_Gabriel_Rossetti_-_Joan_of_Arc_(1882).jpg</filename>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">c21d5fecf9d0310858d2bfe44e5436ce</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1508276690000</fslastmodified>
+  </fileinfo>
+  <filestatus>
+    <well-formed toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">true</valid>
+  </filestatus>
+  <metadata>
+    <image>
+      <byteOrder toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">JPEG</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.16">512</imageWidth>
+      <imageHeight toolname="Exiftool" toolversion="10.00">583</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">YCbCr</colorSpace>
+      <iccProfileName toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">c2</iccProfileName>
+      <YCbCrSubSampling toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.16">in.</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Exiftool" toolversion="10.00">128</xSamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="10.00">128</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.16">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">3</samplesPerPixel>
+      <lightSource toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">unknown</lightSource>
+      <iccProfileVersion toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
+    </image>
+  </metadata>
+  <statistics fitsExecutionTime="722">
+    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+    <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
+    <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="Droid" toolversion="6.3" executionTime="151" />
+    <tool toolname="Jhove" toolversion="1.16" executionTime="644" />
+    <tool toolname="file utility" toolversion="5.25" executionTime="545" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="629" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="592" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="148" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="537" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="635" />
+  </statistics>
+</fits>
+

--- a/spec/services/file_characterization_spec.rb
+++ b/spec/services/file_characterization_spec.rb
@@ -8,30 +8,60 @@ RSpec.describe FileCharacterization do
   }
 
   let(:obj) { FactoryGirl.create(:component) }
-  let(:fits_output) { "<fits/>" }
+  let(:fits_output) { fixture_file_upload('fits.xml') }
+  let(:fits_xml) { fits_output.read }
 
   describe "when there is an error running FITS" do
     before {
       allow(subject).to receive(:run_fits).and_raise(FileCharacterization::FITSError)
     }
-    specify {
+    it "does not add content to the `fits` datastream" do
       begin
         subject.call
       rescue FileCharacterization::FITSError
       ensure
         expect(subject.fits).not_to have_content
       end
-    }
+    end
   end
 
   describe "when FITS runs successfully" do
     before {
-      allow(subject).to receive(:run_fits) { fits_output }
+      allow(subject).to receive(:run_fits) { fits_xml }
     }
-    specify {
+    it "persists the FITS XML output to the `fits` datastream" do
       subject.call
-      expect(subject.fits.content).to eq(fits_output)
-    }
+      expect(subject.fits.content).to be_equivalent_to(fits_xml)
+    end
+    describe "when the FITS media type has a single value" do
+      describe "that is different from the content datastream mimeType" do
+        before do
+          obj.content.mimeType = "application/octet-stream"
+          obj.save!
+        end
+        it "updates the content datastream mimeType" do
+          expect(obj.content.mimeType).to eq "application/octet-stream"
+          expect_any_instance_of(obj.content.class).to receive(:save).and_call_original
+          subject.call
+          obj.reload
+          expect(obj.content.mimeType).to eq "image/jpeg"
+        end
+      end
+      describe "that is the same as the content datastream mimeType" do
+        before do
+          obj.content.mimeType = "image/jpeg"
+          obj.save!
+        end
+        it "does not update the content datastream mimeType" do
+          expect_any_instance_of(obj.content.class).not_to receive(:save)
+        end
+      end
+    end
+    describe "when the FITS media type has multiple values (conflict)" do
+      it "does not update the content datastream mimeType" do
+        expect_any_instance_of(obj.content.class).not_to receive(:save)
+      end
+    end
   end
 
 end

--- a/spec/services/file_characterization_spec.rb
+++ b/spec/services/file_characterization_spec.rb
@@ -54,12 +54,17 @@ RSpec.describe FileCharacterization do
         end
         it "does not update the content datastream mimeType" do
           expect_any_instance_of(obj.content.class).not_to receive(:save)
+          subject.call
         end
       end
     end
     describe "when the FITS media type has multiple values (conflict)" do
+      before do
+        allow_any_instance_of(obj.techmd.class).to receive(:media_type) { ["image/jpeg", "image/tiff"] }
+      end
       it "does not update the content datastream mimeType" do
         expect_any_instance_of(obj.content.class).not_to receive(:save)
+        subject.call
       end
     end
   end


### PR DESCRIPTION
To correct content datastream media type, if possible, based on
information from FITS. Triggered by save of `fits` datastream.
Solves DDR-463.