### PR TITLE
BatchFixityCheck should respect provided limit on objects not checked…

### DIFF
--- a/app/services/batch_fixity_check.rb
+++ b/app/services/batch_fixity_check.rb
@@ -27,6 +27,7 @@ class BatchFixityCheck
   def self.last_checked(before_days: nil, limit: nil)
     Ddr::Index::Query.build(before_days, limit) do |days, max|
       asc :last_fixity_check_on
+      limit max if max
       if days
         before_days(:last_fixity_check_on, days)
       else

--- a/lib/dul_hydra/version.rb
+++ b/lib/dul_hydra/version.rb
@@ -1,3 +1,3 @@
 module DulHydra
-  VERSION = "4.11.3"
+  VERSION = "4.11.4"
 end

--- a/spec/services/batch_fixity_check_spec.rb
+++ b/spec/services/batch_fixity_check_spec.rb
@@ -31,4 +31,16 @@ RSpec.describe BatchFixityCheck do
     end
   end
 
+  describe "with more objects than the limit that were last checked one year ago" do
+    let(:obj2) { FactoryGirl.create(:item) }
+    before do
+      Ddr::Events::FixityCheckEvent.create(pid: obj.pid, event_date_time: Time.now.ago(1.year).utc)
+      Ddr::Events::FixityCheckEvent.create(pid: obj2.pid, event_date_time: Time.now.ago(1.year).utc)
+    end
+    it "should not queue the excess pid's for fixity checking" do
+      expect(Resque).to receive(:enqueue).with(FixityCheckJob, instance_of(String)).once
+      described_class.call(limit: 1)
+    end
+  end
+
 end


### PR DESCRIPTION
… recently (as well as never-checked objects); DDR-1495.